### PR TITLE
Enable scissoring on ContainerLayers

### DIFF
--- a/layers.rs
+++ b/layers.rs
@@ -9,6 +9,7 @@
 
 use geom::matrix::{Matrix4, identity};
 use geom::size::Size2D;
+use geom::rect::Rect;
 use opengles::gl2::{GLuint, delete_textures};
 use std::managed::mut_ptr_eq;
 
@@ -64,6 +65,7 @@ pub struct ContainerLayer {
     common: CommonLayer,
     first_child: Option<Layer>,
     last_child: Option<Layer>,
+    scissor: Option<Rect<f32>>,
 }
 
 
@@ -72,6 +74,7 @@ pub fn ContainerLayer() -> ContainerLayer {
         common: CommonLayer(),
         first_child: None,
         last_child: None,
+        scissor: None,
     }
 }
 


### PR DESCRIPTION
This allows cropping of ContainerLayers, so iframes cannot draw outside a window set by their parents. Depends on https://github.com/mozilla-servo/rust-opengles/pull/47.
