### PR TITLE
Implement cross-process surfaces on both Mac and Linux.

### DIFF
--- a/layers.rc
+++ b/layers.rc
@@ -16,8 +16,29 @@ extern mod std;
 extern mod geom;
 extern mod opengles;
 
+#[cfg(target_os="macos")]
+extern mod core_foundation;
+#[cfg(target_os="macos")]
+extern mod io_surface;
+
+#[cfg(target_os="linux")]
+extern mod xlib;
+
 pub mod layers;
-pub mod scene;
 pub mod rendergl;
+pub mod scene;
+pub mod texturegl;
 pub mod util;
+
+pub mod platform {
+    #[cfg(target_os="linux")]
+    pub mod linux {
+        pub mod surface;
+    }
+    #[cfg(target_os="macos")]
+    pub mod macos {
+        pub mod surface;
+    }
+    pub mod surface;
+}
 

--- a/platform/linux/surface.rs
+++ b/platform/linux/surface.rs
@@ -1,0 +1,323 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation of cross-process surfaces for Linux. This uses X pixmaps.
+
+use platform::surface::NativeSurfaceMethods;
+use texturegl::Texture;
+
+use extra::arc::Arc;
+use geom::size::Size2D;
+use opengles::glx::{GLXFBConfig, GLXDrawable, GLXPixmap, GLX_BIND_TO_TEXTURE_RGBA_EXT};
+use opengles::glx::{GLX_DEPTH_SIZE, GLX_DRAWABLE_TYPE, GLX_FRONT_EXT, GLX_PIXMAP_BIT, GLX_RGBA};
+use opengles::glx::{GLX_TEXTURE_2D_EXT, GLX_TEXTURE_FORMAT_EXT, GLX_TEXTURE_FORMAT_RGBA_EXT};
+use opengles::glx::{GLX_TEXTURE_TARGET_EXT, glXChooseVisual, glXCreatePixmap, glXDestroyPixmap};
+use opengles::glx::{glXGetFBConfigs, glXGetProcAddress, glXGetFBConfigAttrib, glXGetFBConfigs};
+use opengles::glx::{glXGetVisualFromFBConfig};
+use opengles::glx;
+use opengles::gl2::NO_ERROR;
+use opengles::gl2;
+use std::cast;
+use std::libc::{c_char, c_int, c_uint, c_void};
+use std::ptr;
+use xlib::xlib::{Display, Pixmap, XCloseDisplay, XCreateGC, XCreateImage, XCreatePixmap};
+use xlib::xlib::{XDefaultScreen, XFreePixmap, XGetGeometry, XOpenDisplay, XPutImage, XRootWindow};
+use xlib::xlib::{XVisualInfo, ZPixmap};
+
+/// The display and visual info. This is needed in order to upload on the painting side. This holds
+/// a *strong* reference to the display and will close it when done.
+///
+/// FIXME(pcwalton): Mark nonsendable and noncopyable.
+pub struct NativePaintingGraphicsContext {
+    display: *Display,
+    visual_info: *XVisualInfo,
+}
+
+impl NativePaintingGraphicsContext {
+    #[fixed_stack_segment]
+    pub fn from_metadata(metadata: &NativeGraphicsMetadata) -> NativePaintingGraphicsContext {
+        unsafe {
+            let display = XOpenDisplay(*metadata);
+
+            // FIXME(pcwalton): It would be more robust to actually have the compositor pass the
+            // visual.
+            let compositor_visual_info =
+                NativeCompositingGraphicsContext::compositor_visual_info(display);
+
+            NativePaintingGraphicsContext {
+                display: display,
+                visual_info: compositor_visual_info,
+            }
+        }
+    }
+}
+
+impl Drop for NativePaintingGraphicsContext {
+    #[fixed_stack_segment]
+    fn drop(&mut self) {
+        unsafe {
+            let _ = XCloseDisplay(self.display);
+        }
+    }
+}
+
+/// The display, visual info, and framebuffer configuration. This is needed in order to bind to a
+/// texture on the compositor side. This holds only a *weak* reference to the display and does not
+/// close it.
+///
+/// FIXME(pcwalton): Unchecked weak references are bad and can violate memory safety. This is hard
+/// to fix because the Display is given to us by the native windowing system, but we should fix it
+/// someday.
+///
+/// FIXME(pcwalton): Mark nonsendable.
+pub struct NativeCompositingGraphicsContext {
+    display: *Display,
+    visual_info: *XVisualInfo,
+    framebuffer_configuration: GLXFBConfig,
+}
+
+impl NativeCompositingGraphicsContext {
+    /// Chooses the compositor visual info using the same algorithm that the compositor uses.
+    ///
+    /// FIXME(pcwalton): It would be more robust to actually have the compositor pass the visual.
+    #[fixed_stack_segment]
+    fn compositor_visual_info(display: *Display) -> *XVisualInfo {
+        unsafe {
+            let glx_display: *glx::Display = cast::transmute(display);
+            let screen = XDefaultScreen(display);
+            let attributes = [ GLX_RGBA, GLX_DEPTH_SIZE, 24, 0 ];
+            let compositor_visual_info = glXChooseVisual(glx_display, screen, &attributes[0]);
+            cast::transmute(compositor_visual_info)
+        }
+    }
+
+    /// Creates a native graphics context from the given X display connection. This uses GLX. Only
+    /// the compositor is allowed to call this.
+    #[fixed_stack_segment]
+    pub fn from_display(display: *Display) -> NativeCompositingGraphicsContext {
+        unsafe {
+            // FIXME(pcwalton): It would be more robust to actually have the compositor pass the
+            // visual.
+            let compositor_visual_info =
+                NativeCompositingGraphicsContext::compositor_visual_info(display);
+            let compositor_visual_id = (*compositor_visual_info).visualid;
+
+            // Choose an FB config.
+            let glx_display = cast::transmute(display);
+            let screen = XDefaultScreen(display);
+            let mut fbconfig_count = 0;
+            let fbconfigs = glXGetFBConfigs(glx_display, screen, &mut fbconfig_count);
+            let mut fbconfig_index = None;
+            for i in range(0, fbconfig_count) {
+                let fbconfig = *ptr::offset(fbconfigs, i as int);
+                let visual_info = glXGetVisualFromFBConfig(glx_display, fbconfig);
+                let visual_info: *XVisualInfo = cast::transmute(visual_info);
+                if visual_info == ptr::null() || (*visual_info).visualid != compositor_visual_id {
+                    continue
+                }
+
+                let mut value = 0;
+                glXGetFBConfigAttrib(glx_display, fbconfig, GLX_DRAWABLE_TYPE, &mut value);
+                if (value & GLX_PIXMAP_BIT) == 0 {
+                    continue
+                }
+
+                glXGetFBConfigAttrib(glx_display,
+                                     fbconfig,
+                                     GLX_BIND_TO_TEXTURE_RGBA_EXT,
+                                     &mut value);
+                if value == 0 {
+                    continue
+                }
+
+                fbconfig_index = Some(i);
+                break
+            }
+
+            let framebuffer_configuration = match fbconfig_index {
+                None => fail!("No appropriate framebuffer config found!"),
+                Some(index) => *ptr::offset(fbconfigs, index as int),
+            };
+
+            NativeCompositingGraphicsContext {
+                display: display,
+                visual_info: compositor_visual_info,
+                framebuffer_configuration: framebuffer_configuration,
+            }
+        }
+    }
+}
+
+/// The X display string.
+pub type NativeGraphicsMetadata = *c_char;
+
+#[deriving(Eq)]
+pub enum NativeSurfaceTransientData {
+    NoTransientData,
+    RenderTaskTransientData(*Display, *XVisualInfo),
+}
+
+pub struct NativeSurface {
+    /// The pixmap.
+    pixmap: Pixmap,
+
+    /// Whether this pixmap will leak if the destructor runs. This is for debugging purposes.
+    will_leak: bool,
+}
+
+impl Drop for NativeSurface {
+    fn drop(&mut self) {
+        if self.will_leak {
+            fail!("You should have disposed of the pixmap properly with destroy()! This pixmap \
+                   will leak!");
+        }
+    }
+}
+
+impl NativeSurface {
+    #[fixed_stack_segment]
+    pub fn from_pixmap(pixmap: Pixmap) -> NativeSurface {
+        NativeSurface {
+            pixmap: pixmap,
+            will_leak: true,
+        }
+    }
+}
+
+impl NativeSurfaceMethods for NativeSurface {
+    #[fixed_stack_segment]
+    fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>, stride: i32)
+           -> NativeSurface {
+        unsafe {
+            // Create the pixmap.
+            let screen = XDefaultScreen(native_context.display);
+            let window = XRootWindow(native_context.display, screen);
+
+            let pixmap = XCreatePixmap(native_context.display,
+                                       window,
+                                       size.width as c_uint,
+                                       size.height as c_uint,
+                                       ((stride / size.width) * 8) as c_uint);
+
+            NativeSurface::from_pixmap(pixmap)
+        }
+    }
+
+    /// This may only be called on the compositor side.
+    #[fixed_stack_segment]
+    fn bind_to_texture(&self,
+                       native_context: &NativeCompositingGraphicsContext,
+                       texture: &Texture,
+                       size: Size2D<int>) {
+        unsafe {
+            // Create the GLX pixmap.
+            //
+            // FIXME(pcwalton): RAII for exception safety?
+            let pixmap_attributes = [
+                GLX_TEXTURE_TARGET_EXT, GLX_TEXTURE_2D_EXT,
+                GLX_TEXTURE_FORMAT_EXT, GLX_TEXTURE_FORMAT_RGBA_EXT,
+                0
+            ];
+            let glx_display = cast::transmute(native_context.display);
+            let glx_pixmap = glXCreatePixmap(glx_display,
+                                             native_context.framebuffer_configuration,
+                                             self.pixmap,
+                                             &pixmap_attributes[0]);
+
+            let glXBindTexImageEXT: extern "C" fn(*Display, GLXDrawable, c_int, *c_int) =
+                cast::transmute(glXGetProcAddress(cast::transmute(&"glXBindTexImageEXT\x00"[0])));
+            assert!(glXBindTexImageEXT as *c_void != ptr::null());
+            let _bound = texture.bind();
+            glXBindTexImageEXT(native_context.display,
+                               cast::transmute(glx_pixmap),
+                               GLX_FRONT_EXT,
+                               ptr::null());
+            assert_eq!(gl2::get_error(), NO_ERROR);
+
+            // FIXME(pcwalton): Recycle these for speed?
+            glXDestroyPixmap(glx_display, glx_pixmap);
+        }
+    }
+
+    /// This may only be called on the painting side.
+    #[fixed_stack_segment]
+    fn upload(&self, graphics_context: &NativePaintingGraphicsContext, data: &[u8]) {
+        unsafe {
+            // Ensure that we're running on the render task. Take the display.
+            let pixmap = self.pixmap;
+
+            // Figure out the width, height, and depth of the pixmap.
+            let mut root_window = 0;
+            let mut x = 0;
+            let mut y = 0;
+            let mut width = 0;
+            let mut height = 0;
+            let mut border_width = 0;
+            let mut depth = 0;
+            let _ = XGetGeometry(graphics_context.display,
+                                 cast::transmute(pixmap),
+                                 &mut root_window,
+                                 &mut x,
+                                 &mut y,
+                                 &mut width,
+                                 &mut height,
+                                 &mut border_width,
+                                 &mut depth);
+
+            // Create the image.
+            let image = XCreateImage(graphics_context.display,
+                                     (*graphics_context.visual_info).visual,
+                                     depth,
+                                     ZPixmap,
+                                     0,
+                                     cast::transmute(&data[0]),
+                                     width as c_uint,
+                                     height as c_uint,
+                                     32,
+                                     0);
+
+            // Create the X graphics context.
+            let gc = XCreateGC(graphics_context.display, pixmap, 0, ptr::null());
+
+            // Draw the image.
+            let _ = XPutImage(graphics_context.display,
+                              pixmap,
+                              gc,
+                              image,
+                              0,
+                              0,
+                              0,
+                              0,
+                              width,
+                              height);
+        }
+    }
+
+    fn get_id(&self) -> int {
+        self.pixmap as int
+    }
+
+    #[fixed_stack_segment]
+    fn destroy(&mut self, graphics_context: &NativePaintingGraphicsContext) {
+        unsafe {
+            assert!(self.pixmap != 0);
+            XFreePixmap(graphics_context.display, self.pixmap);
+            self.mark_wont_leak()
+        }
+    }
+
+    fn mark_will_leak(&mut self) {
+        self.will_leak = true
+    }
+
+    fn mark_wont_leak(&mut self) {
+        self.will_leak = false
+    }
+}
+

--- a/platform/macos/surface.rs
+++ b/platform/macos/surface.rs
@@ -1,0 +1,138 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Mac OS-specific implementation of cross-process surfaces. This uses `IOSurface`, introduced
+//! in Mac OS X 10.6 Snow Leopard.
+
+use core_foundation::boolean::CFBoolean;
+use core_foundation::dictionary::CFDictionary;
+use core_foundation::number::CFNumber;
+use core_foundation::string::CFString;
+use geom::size::Size2D;
+use io_surface::{kIOSurfaceBytesPerElement, kIOSurfaceBytesPerRow, kIOSurfaceHeight};
+use io_surface::{kIOSurfaceIsGlobal, kIOSurfaceWidth, IOSurface};
+use io_surface;
+use opengles::cgl::CGLPixelFormatObj;
+use platform::surface::NativeSurfaceMethods;
+use std::util;
+use texturegl::Texture;
+
+pub struct NativeGraphicsMetadata {
+    pixel_format: CGLPixelFormatObj,
+}
+
+pub struct NativePaintingGraphicsContext {
+    metadata: NativeGraphicsMetadata,
+}
+
+impl NativePaintingGraphicsContext {
+    pub fn from_metadata(metadata: &NativeGraphicsMetadata) -> NativePaintingGraphicsContext {
+        NativePaintingGraphicsContext {
+            metadata: *metadata,
+        }
+    }
+}
+
+impl Drop for NativePaintingGraphicsContext {
+    fn drop(&mut self) {}
+}
+
+pub struct NativeCompositingGraphicsContext {
+    contents: (),
+}
+
+impl NativeCompositingGraphicsContext {
+    pub fn new() -> NativeCompositingGraphicsContext {
+        NativeCompositingGraphicsContext {
+            contents: (),
+        }
+    }
+}
+
+pub struct NativeSurface {
+    io_surface: Option<IOSurface>,
+    will_leak: bool,
+}
+
+impl NativeSurface {
+    #[fixed_stack_segment]
+    pub fn from_io_surface(io_surface: IOSurface) -> NativeSurface {
+        NativeSurface {
+            io_surface: Some(io_surface),
+            will_leak: true,
+        }
+    }
+}
+
+impl NativeSurfaceMethods for NativeSurface {
+    fn new(_: &NativePaintingGraphicsContext, size: Size2D<i32>, stride: i32) -> NativeSurface {
+        let width_key = CFString::wrap_shared(kIOSurfaceWidth);
+        let width_value = CFNumber::new(size.width);
+
+        let height_key = CFString::wrap_shared(kIOSurfaceHeight);
+        let height_value = CFNumber::new(size.height);
+
+        let bytes_per_row_key = CFString::wrap_shared(kIOSurfaceBytesPerRow);
+        let bytes_per_row_value = CFNumber::new(stride);
+
+        let bytes_per_elem_key = CFString::wrap_shared(kIOSurfaceBytesPerElement);
+        let bytes_per_elem_value = CFNumber::new(4i32);
+
+        let is_global_key = CFString::wrap_shared(kIOSurfaceIsGlobal);
+        let is_global_value = CFBoolean::true_value();
+
+        let surface = io_surface::new(&CFDictionary::new([
+            (*width_key.contents.borrow_ref(), *width_value.contents.borrow_type_ref()),
+            (*height_key.contents.borrow_ref(), *height_value.contents.borrow_type_ref()),
+            (*bytes_per_row_key.contents.borrow_ref(),
+             *bytes_per_row_value.contents.borrow_type_ref()),
+            (*bytes_per_elem_key.contents.borrow_ref(),
+             *bytes_per_elem_value.contents.borrow_type_ref()),
+            (*is_global_key.contents.borrow_ref(), *is_global_value.contents.borrow_type_ref()),
+        ]));
+
+        NativeSurface {
+            io_surface: Some(surface),
+            will_leak: true,
+        }
+    }
+
+    fn bind_to_texture(&self,
+                       _: &NativeCompositingGraphicsContext,
+                       texture: &Texture,
+                       size: Size2D<int>) {
+        let _bound_texture = texture.bind();
+        self.io_surface.get_ref().bind_to_gl_texture(size)
+    }
+
+    fn upload(&self, _: &NativePaintingGraphicsContext, data: &[u8]) {
+        self.io_surface.get_ref().upload(data)
+    }
+
+    fn get_id(&self) -> int {
+        match self.io_surface {
+            None => 0,
+            Some(ref io_surface) => io_surface.get_id() as int,
+        }
+    }
+
+    fn destroy(&mut self, _: &NativePaintingGraphicsContext) {
+        let _ = util::replace(&mut self.io_surface, None);
+        self.mark_wont_leak()
+    }
+
+    fn mark_will_leak(&mut self) {
+        self.will_leak = true
+    }
+
+    fn mark_wont_leak(&mut self) {
+        self.will_leak = false
+    }
+}
+

--- a/platform/surface.rs
+++ b/platform/surface.rs
@@ -1,0 +1,75 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation of cross-process surfaces. This delegates to the platform-specific
+//! implementation.
+
+use texturegl::Texture;
+
+use geom::size::Size2D;
+
+#[cfg(target_os="macos")]
+pub use platform::macos::surface::NativePaintingGraphicsContext;
+#[cfg(target_os="macos")]
+pub use platform::macos::surface::NativeCompositingGraphicsContext;
+#[cfg(target_os="macos")]
+pub use platform::macos::surface::NativeGraphicsMetadata;
+#[cfg(target_os="macos")]
+pub use platform::macos::surface::NativeSurface;
+#[cfg(target_os="linux")]
+pub use platform::linux::surface::NativePaintingGraphicsContext;
+#[cfg(target_os="linux")]
+pub use platform::linux::surface::NativeCompositingGraphicsContext;
+#[cfg(target_os="linux")]
+pub use platform::linux::surface::NativeGraphicsMetadata;
+#[cfg(target_os="linux")]
+pub use platform::linux::surface::NativeSurface;
+
+pub trait NativeSurfaceMethods {
+    /// Creates a new native surface with uninitialized data.
+    fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>, stride: i32) -> Self;
+
+    /// Binds the surface to a GPU texture. Compositing task only.
+    fn bind_to_texture(&self,
+                       native_context: &NativeCompositingGraphicsContext,
+                       texture: &Texture,
+                       size: Size2D<int>);
+
+    /// Uploads pixel data to the surface. Painting task only.
+    fn upload(&self, native_context: &NativePaintingGraphicsContext, data: &[u8]);
+
+    /// Returns an opaque ID identifying the surface for debugging.
+    fn get_id(&self) -> int;
+
+    /// Destroys the surface. After this, it is an error to use the surface. Painting task only.
+    fn destroy(&mut self, graphics_context: &NativePaintingGraphicsContext);
+
+    /// Records that the surface will leak if destroyed. This is done by the compositor immediately
+    /// after receiving the surface.
+    fn mark_will_leak(&mut self);
+
+    /// Marks the surface as not leaking. The painting task and the compositing task call this when
+    /// they are certain that the surface will not leak. For example:
+    ///
+    /// 1. When sending buffers back to the render task, either the render task will receive them
+    ///    or the render task has crashed. In the former case, they're the render task's
+    ///    responsibility, so this is OK. In the latter case, the kernel or window server is going
+    ///    to clean up the layer buffers. Either way, no leaks.
+    ///
+    /// 2. If the compositor is shutting down, the render task is also shutting down. In that case
+    ///    it will destroy all its pixmaps, so no leak.
+    ///
+    /// 3. If the painting task is sending buffers to the compositor, then they are marked as not
+    ///    leaking, because of the possibility that the compositor will die before the buffers are
+    ///    destroyed.
+    ///
+    /// This helps debug leaks. For performance this may want to become a no-op in the future.
+    fn mark_wont_leak(&mut self);
+}
+

--- a/rendergl.rs
+++ b/rendergl.rs
@@ -7,249 +7,304 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use layers::{ContainerLayerKind, Flip, NoFlip, TextureLayerKind, VerticalFlip};
 use layers;
-use layers::{ARGB32Format, ContainerLayerKind, TextureLayerKind, Image, ImageLayerKind, RGB24Format};
-use layers::{TiledImageLayerKind};
 use scene::Scene;
+use texturegl::{Texture, TextureTarget2D, TextureTargetRectangle};
 
 use geom::matrix::{Matrix4, ortho};
 use geom::point::Point2D;
 use geom::size::Size2D;
 use geom::rect::Rect;
-use opengles::gl2::{ARRAY_BUFFER, COLOR_BUFFER_BIT, CLAMP_TO_EDGE, COMPILE_STATUS};
-use opengles::gl2::{FRAGMENT_SHADER, LINK_STATUS, LINEAR, NO_ERROR, RGB, RGBA, BGRA, SCISSOR_BOX};
-use opengles::gl2::{SCISSOR_TEST, STATIC_DRAW, TEXTURE_2D, TEXTURE_MAG_FILTER, TEXTURE_MIN_FILTER};
-use opengles::gl2::{TEXTURE_WRAP_S, TEXTURE_WRAP_T, TEXTURE0};
-use opengles::gl2::{TRIANGLE_STRIP, UNPACK_ALIGNMENT, UNPACK_CLIENT_STORAGE_APPLE};
-use opengles::gl2::{UNPACK_ROW_LENGTH, UNSIGNED_BYTE, UNSIGNED_INT_8_8_8_8_REV, VERTEX_SHADER, VIEWPORT};
-use opengles::gl2::{GLenum, GLint, GLsizei, GLuint, attach_shader, bind_buffer};
-use opengles::gl2::{bind_texture, buffer_data, create_program, clear, clear_color};
-use opengles::gl2::{compile_shader, create_shader, draw_arrays, disable, enable, is_enabled};
-use opengles::gl2::{enable_vertex_attrib_array, gen_buffers, gen_textures};
-use opengles::gl2::{get_attrib_location, get_error, get_integer_v, get_program_iv};
-use opengles::gl2::{get_shader_info_log, get_shader_iv, active_texture};
-use opengles::gl2::{get_uniform_location, link_program, pixel_store_i, scissor, shader_source};
-use opengles::gl2::{tex_image_2d, tex_parameter_i, uniform_1i, uniform_matrix_4fv, use_program};
-use opengles::gl2::{vertex_attrib_pointer_f32, viewport};
-
+use opengles::gl2::{ARRAY_BUFFER, COLOR_BUFFER_BIT, COMPILE_STATUS, FRAGMENT_SHADER, LINK_STATUS};
+use opengles::gl2::{NO_ERROR, SCISSOR_BOX, SCISSOR_TEST, STATIC_DRAW, TEXTURE_2D};
+use opengles::gl2::{TEXTURE_RECTANGLE_ARB, TEXTURE0, TRIANGLE_STRIP, VERTEX_SHADER, VIEWPORT};
+use opengles::gl2::{GLenum, GLfloat, GLint, GLsizei, GLuint, active_texture, attach_shader};
+use opengles::gl2::{bind_buffer, bind_texture, buffer_data, create_program, clear, clear_color};
+use opengles::gl2::{compile_shader};
+use opengles::gl2::{create_shader, draw_arrays, disable, enable, enable_vertex_attrib_array};
+use opengles::gl2::{gen_buffers, get_attrib_location, get_error, get_integer_v, get_program_iv};
+use opengles::gl2::{get_shader_info_log, get_shader_iv, get_uniform_location, is_enabled};
+use opengles::gl2::{link_program, scissor, shader_source, uniform_1i, uniform_2f};
+use opengles::gl2::{uniform_matrix_4fv, use_program, vertex_attrib_pointer_f32, viewport};
 use std::libc::c_int;
-use std::libc::c_uint;
 
-pub fn FRAGMENT_SHADER_SOURCE() -> ~str {
-    ~"
-        #ifdef GL_ES
-            precision mediump float;
-        #endif
+static FRAGMENT_2D_SHADER_SOURCE: &'static str = "
+    #ifdef GL_ES
+        precision mediump float;
+    #endif
 
-        varying vec2 vTextureCoord;
+    varying vec2 vTextureCoord;
 
-        uniform sampler2D uSampler;
+    uniform sampler2D uSampler;
 
-        void main(void) {
-            gl_FragColor = texture2D(uSampler, vTextureCoord);
-        }
-    "
-}
+    void main(void) {
+        gl_FragColor = texture2D(uSampler, vTextureCoord);
+    }
+";
 
-pub fn VERTEX_SHADER_SOURCE() -> ~str {
-    ~"
-        attribute vec3 aVertexPosition;
-        attribute vec2 aTextureCoord;
+static FRAGMENT_RECTANGLE_SHADER_SOURCE: &'static str = "
+    #ifdef GL_ES
+        precision mediump float;
+    #endif
 
-        uniform mat4 uMVMatrix;
-        uniform mat4 uPMatrix;
+    varying vec2 vTextureCoord;
 
-        varying vec2 vTextureCoord;
+    uniform sampler2DRect uSampler;
+    uniform vec2 uSize;
 
-        void main(void) {
-            gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
-            vTextureCoord = aTextureCoord;
-        }
-    "
-}
+    void main(void) {
+        gl_FragColor = texture2DRect(uSampler, vTextureCoord * uSize);
+    }
+";
 
-pub fn load_shader(source_string: ~str, shader_type: GLenum) -> GLuint {
+static VERTEX_SHADER_SOURCE: &'static str = "
+    attribute vec3 aVertexPosition;
+    attribute vec2 aTextureCoord;
+
+    uniform mat4 uMVMatrix;
+    uniform mat4 uPMatrix;
+
+    varying vec2 vTextureCoord;
+
+    void main(void) {
+        gl_Position = uPMatrix * uMVMatrix * vec4(aVertexPosition, 1.0);
+        vTextureCoord = aTextureCoord;
+    }
+";
+
+static VERTICES: [f32, ..12] = [
+    0.0, 0.0, 0.0,
+    0.0, 1.0, 0.0,
+    1.0, 0.0, 0.0,
+    1.0, 1.0, 0.0,
+];
+
+static TEXTURE_COORDINATES: [f32, ..8] = [
+    0.0, 0.0,
+    0.0, 1.0,
+    1.0, 0.0,
+    1.0, 1.0,
+];
+
+static FLIPPED_TEXTURE_COORDINATES: [f32, ..8] = [
+    0.0, 1.0,
+    0.0, 0.0,
+    1.0, 1.0,
+    1.0, 0.0,
+];
+
+pub fn load_shader(source_string: &str, shader_type: GLenum) -> GLuint {
     let shader_id = create_shader(shader_type);
     shader_source(shader_id, [ source_string.as_bytes().to_owned() ]);
     compile_shader(shader_id);
 
     if get_error() != NO_ERROR {
         println(fmt!("error: %d", get_error() as int));
-        fail!(~"failed to compile shader");
+        fail!("failed to compile shader");
     }
 
     if get_shader_iv(shader_id, COMPILE_STATUS) == (0 as GLint) {
         println(fmt!("shader info log: %s", get_shader_info_log(shader_id)));
-        fail!(~"failed to compile shader");
+        fail!("failed to compile shader");
     }
 
     return shader_id;
 }
 
-pub struct RenderContext {
-    program: GLuint,
+struct Buffers {
+    vertex_buffer: GLuint,
+    texture_coordinate_buffer: GLuint,
+    flipped_texture_coordinate_buffer: GLuint,
+}
+
+struct Program2D {
+    id: GLuint,
     vertex_position_attr: c_int,
     texture_coord_attr: c_int,
     modelview_uniform: c_int,
     projection_uniform: c_int,
     sampler_uniform: c_int,
-    vertex_buffer: GLuint,
-    texture_coord_buffer: GLuint,
 }
 
-pub fn RenderContext(program: GLuint) -> RenderContext {
-    let (vertex_buffer, texture_coord_buffer) = init_buffers();
-    let rc = RenderContext {
-        program: program,
-        vertex_position_attr: get_attrib_location(program, "aVertexPosition"),
-        texture_coord_attr: get_attrib_location(program, "aTextureCoord"),
-        modelview_uniform: get_uniform_location(program, "uMVMatrix"),
-        projection_uniform: get_uniform_location(program, "uPMatrix"),
-        sampler_uniform: get_uniform_location(program, "uSampler"),
-        vertex_buffer: vertex_buffer,
-        texture_coord_buffer: texture_coord_buffer,
-    };
-
-    enable_vertex_attrib_array(rc.vertex_position_attr as GLuint);
-    enable_vertex_attrib_array(rc.texture_coord_attr as GLuint);
-
-    rc
+struct ProgramRectangle {
+    id: GLuint,
+    vertex_position_attr: c_int,
+    texture_coord_attr: c_int,
+    modelview_uniform: c_int,
+    projection_uniform: c_int,
+    sampler_uniform: c_int,
+    size_uniform: c_int,
 }
 
-pub fn init_render_context() -> RenderContext {
-    let vertex_shader = load_shader(VERTEX_SHADER_SOURCE(), VERTEX_SHADER);
-    let fragment_shader = load_shader(FRAGMENT_SHADER_SOURCE(), FRAGMENT_SHADER);
+pub struct RenderContext {
+    program_2d: Program2D,
+    program_rectangle: ProgramRectangle,
+    buffers: Buffers,
+}
 
+impl RenderContext {
+    fn new(program_2d: GLuint, program_rectangle: GLuint) -> RenderContext {
+        let render_context = RenderContext {
+            program_2d: Program2D {
+                id: program_2d,
+                vertex_position_attr: get_attrib_location(program_2d, "aVertexPosition"),
+                texture_coord_attr: get_attrib_location(program_2d, "aTextureCoord"),
+                modelview_uniform: get_uniform_location(program_2d, "uMVMatrix"),
+                projection_uniform: get_uniform_location(program_2d, "uPMatrix"),
+                sampler_uniform: get_uniform_location(program_2d, "uSampler"),
+            },
+            program_rectangle: ProgramRectangle {
+                id: program_rectangle,
+                vertex_position_attr: get_attrib_location(program_rectangle, "aVertexPosition"),
+                texture_coord_attr: get_attrib_location(program_rectangle, "aTextureCoord"),
+                modelview_uniform: get_uniform_location(program_rectangle, "uMVMatrix"),
+                projection_uniform: get_uniform_location(program_rectangle, "uPMatrix"),
+                sampler_uniform: get_uniform_location(program_rectangle, "uSampler"),
+                size_uniform: get_uniform_location(program_rectangle, "uSize"),
+            },
+            buffers: RenderContext::init_buffers(),
+        };
+
+        enable_vertex_attrib_array(render_context.program_2d.vertex_position_attr as GLuint);
+        enable_vertex_attrib_array(render_context.program_2d.texture_coord_attr as GLuint);
+        enable_vertex_attrib_array(render_context.program_rectangle.vertex_position_attr as
+            GLuint);
+        enable_vertex_attrib_array(render_context.program_rectangle.texture_coord_attr as GLuint);
+
+        render_context
+    }
+
+    fn init_buffers() -> Buffers {
+        let vertex_buffer = gen_buffers(1)[0];
+        bind_buffer(ARRAY_BUFFER, vertex_buffer);
+        buffer_data(ARRAY_BUFFER, VERTICES, STATIC_DRAW);
+
+        let texture_coordinate_buffer = gen_buffers(1)[0];
+        bind_buffer(ARRAY_BUFFER, texture_coordinate_buffer);
+        buffer_data(ARRAY_BUFFER, TEXTURE_COORDINATES, STATIC_DRAW);
+
+        let flipped_texture_coordinate_buffer = gen_buffers(1)[0];
+        bind_buffer(ARRAY_BUFFER, flipped_texture_coordinate_buffer);
+        buffer_data(ARRAY_BUFFER, FLIPPED_TEXTURE_COORDINATES, STATIC_DRAW);
+
+        Buffers {
+            vertex_buffer: vertex_buffer,
+            texture_coordinate_buffer: texture_coordinate_buffer,
+            flipped_texture_coordinate_buffer: flipped_texture_coordinate_buffer,
+        }
+    }
+}
+
+pub fn init_program(vertex_shader: GLuint, fragment_shader: GLuint) -> GLuint {
     let program = create_program();
     attach_shader(program, vertex_shader);
     attach_shader(program, fragment_shader);
     link_program(program);
-
     if get_program_iv(program, LINK_STATUS) == (0 as GLint) {
-        fail!(~"failed to initialize program");
+        fail!("failed to initialize program");
     }
 
-    use_program(program);
+    program
+}
+
+pub fn init_render_context() -> RenderContext {
+    let vertex_2d_shader = load_shader(VERTEX_SHADER_SOURCE, VERTEX_SHADER);
+    let fragment_2d_shader = load_shader(FRAGMENT_2D_SHADER_SOURCE, FRAGMENT_SHADER);
+    let program_2d = init_program(vertex_2d_shader, fragment_2d_shader);
+
+    let vertex_rectangle_shader = load_shader(VERTEX_SHADER_SOURCE, VERTEX_SHADER);
+    let fragment_rectangle_shader = load_shader(FRAGMENT_RECTANGLE_SHADER_SOURCE, FRAGMENT_SHADER);
+    let program_rectangle = init_program(vertex_rectangle_shader, fragment_rectangle_shader);
+
     enable(TEXTURE_2D);
+    enable(TEXTURE_RECTANGLE_ARB);
 
-    return RenderContext(program);
+    RenderContext::new(program_2d, program_rectangle)
 }
 
-pub fn init_buffers() -> (GLuint, GLuint) {
-    let triangle_vertex_buffer = gen_buffers(1 as GLsizei)[0];
-    bind_buffer(ARRAY_BUFFER, triangle_vertex_buffer);
-
-    let (_0, _1) = (0.0f32, 1.0f32);
-    let vertices = ~[
-        _0, _0, _0,
-        _0, _1, _0,
-        _1, _0, _0,
-        _1, _1, _0
-    ];
-
-    buffer_data(ARRAY_BUFFER, vertices, STATIC_DRAW);
-
-    let texture_coord_buffer = gen_buffers(1 as GLsizei)[0];
-    bind_buffer(ARRAY_BUFFER, texture_coord_buffer);
-
-    return (triangle_vertex_buffer, texture_coord_buffer);
-}
-
-pub fn create_texture_for_image_if_necessary(image: @mut Image) {
-    #[cfg(target_os = "android")]
-    fn colorspace() -> c_uint {
-        RGBA
-    }
-    #[cfg(not(target_os = "android"))]
-    fn colorspace() -> c_uint {
-        BGRA
-    }
-    #[cfg(target_os = "android")]
-    fn datatype() -> c_uint {
-        UNSIGNED_BYTE
-    }
-    #[cfg(not(target_os = "android"))]
-    fn datatype() -> c_uint {
-        UNSIGNED_INT_8_8_8_8_REV
-    }
-
-    match image.texture {
-        None => {}
-        Some(_) => { return; /* Nothing to do. */ }
-    }
-
-    let texture = gen_textures(1 as GLsizei)[0];
-
-    //XXXjdm This block is necessary to avoid a task failure that occurs
-    //       when |image.data| is borrowed and we mutate |image.texture|.
-    {
-    let data = &mut image.data;
-    debug!("making texture, id=%d, format=%?", texture as int, data.format());
-
-    bind_texture(TEXTURE_2D, texture);
-
-    // FIXME: This makes the lifetime requirements somewhat complex...
-    pixel_store_i(UNPACK_CLIENT_STORAGE_APPLE, 1);
-
-    let size = data.size();
-    let stride = data.stride() as GLsizei;
-
-    tex_parameter_i(TEXTURE_2D, TEXTURE_MAG_FILTER, LINEAR as GLint);
-    tex_parameter_i(TEXTURE_2D, TEXTURE_MIN_FILTER, LINEAR as GLint);
-
-    tex_parameter_i(TEXTURE_2D, TEXTURE_WRAP_S, CLAMP_TO_EDGE as GLint);
-    tex_parameter_i(TEXTURE_2D, TEXTURE_WRAP_T, CLAMP_TO_EDGE as GLint);
-
-    // These two are needed for DMA on the Mac. Don't touch them unless you know what you're doing!
-    pixel_store_i(UNPACK_ALIGNMENT, 4);
-    pixel_store_i(UNPACK_ROW_LENGTH, size.width as GLint);
-    if stride % 32 != 0 {
-        info!("rust-layers: suggest using stride multiples of 32 for DMA on the Mac");
-    }
-
-    debug!("rust-layers stride is %u", stride as uint);
-
-    match data.format() {
-        RGB24Format => {
-            do data.with_data |data| {
-                tex_image_2d(TEXTURE_2D, 0 as GLint, RGB as GLint,
-                             size.width as GLsizei, size.height as GLsizei, 0 as GLint, RGB,
-                             UNSIGNED_BYTE, Some(data));
-            }
-        }
-        ARGB32Format => {
-            do data.with_data |data| {
-                tex_image_2d(TEXTURE_2D, 0 as GLint, RGBA as GLint,
-                             size.width as GLsizei, size.height as GLsizei, 0 as GLint, colorspace(),
-                             datatype(), Some(data));
-            }
+fn bind_texture_coordinate_buffer(render_context: RenderContext, flip: Flip) {
+    match flip {
+        NoFlip => bind_buffer(ARRAY_BUFFER, render_context.buffers.texture_coordinate_buffer),
+        VerticalFlip => {
+            bind_buffer(ARRAY_BUFFER, render_context.buffers.flipped_texture_coordinate_buffer)
         }
     }
-    } //XXXjdm This block avoids a segfault. See opening comment.
-
-    image.texture = Some(texture);
 }
 
-pub fn bind_and_render_quad(render_context: RenderContext, texture: GLuint) {
+pub fn bind_and_render_quad(render_context: RenderContext,
+                            texture: &Texture,
+                            flip: Flip,
+                            transform: &Matrix4<f32>,
+                            scene_size: Size2D<f32>) {
+    let program_id = match texture.target {
+        TextureTarget2D => render_context.program_2d.id,
+        TextureTargetRectangle(*) => render_context.program_rectangle.id,
+    };
+
+    use_program(program_id);
     active_texture(TEXTURE0);
-    bind_texture(TEXTURE_2D, texture);
+    let _bound_texture = texture.bind();
 
-    uniform_1i(render_context.sampler_uniform, 0);
+    // Set the projection matrix.
+    let projection_matrix = ortho(0.0, scene_size.width, scene_size.height, 0.0, -10.0, 10.0);
 
-    bind_buffer(ARRAY_BUFFER, render_context.vertex_buffer);
-    vertex_attrib_pointer_f32(render_context.vertex_position_attr as GLuint, 3, false, 0, 0);
+    // Set uniforms and vertex attribute pointers.
+    match texture.target {
+        TextureTarget2D => {
+            uniform_1i(render_context.program_2d.sampler_uniform, 0);
+            uniform_matrix_4fv(render_context.program_2d.modelview_uniform,
+                               false,
+                               transform.to_array());
+            uniform_matrix_4fv(render_context.program_2d.projection_uniform,
+                               false,
+                               projection_matrix.to_array());
 
-    // Create the texture coordinate array.
-    bind_buffer(ARRAY_BUFFER, render_context.texture_coord_buffer);
+            bind_buffer(ARRAY_BUFFER, render_context.buffers.vertex_buffer);
+            vertex_attrib_pointer_f32(render_context.program_2d.vertex_position_attr as GLuint,
+                                      3,
+                                      false,
+                                      0,
+                                      0);
 
-    let vertices = [
-        0.0f32, 1.0f32,
-        0.0f32, 0.0f32,
-        1.0f32, 1.0f32,
-        1.0f32, 0.0f32,
-    ];
-    buffer_data(ARRAY_BUFFER, vertices, STATIC_DRAW);
-    vertex_attrib_pointer_f32(render_context.texture_coord_attr as GLuint, 2, false, 0, 0);
+            bind_texture_coordinate_buffer(render_context, flip);
+            vertex_attrib_pointer_f32(render_context.program_2d.texture_coord_attr as GLuint,
+                                      2,
+                                      false,
+                                      0,
+                                      0);
+        }
+        TextureTargetRectangle(size) => {
+            uniform_1i(render_context.program_rectangle.sampler_uniform, 0);
+            uniform_2f(render_context.program_rectangle.size_uniform,
+                       size.width as GLfloat,
+                       size.height as GLfloat);
+            uniform_matrix_4fv(render_context.program_rectangle.modelview_uniform,
+                               false,
+                               transform.to_array());
+            uniform_matrix_4fv(render_context.program_rectangle.projection_uniform,
+                               false,
+                               projection_matrix.to_array());
+
+            bind_buffer(ARRAY_BUFFER, render_context.buffers.vertex_buffer);
+            vertex_attrib_pointer_f32(render_context.program_rectangle.vertex_position_attr as
+                                      GLuint,
+                                      3,
+                                      false,
+                                      0,
+                                      0);
+
+            bind_texture_coordinate_buffer(render_context, flip);
+            vertex_attrib_pointer_f32(render_context.program_rectangle.texture_coord_attr as
+                                      GLuint,
+                                      2,
+                                      false,
+                                      0,
+                                      0);
+        }
+    }
+
+    // Draw!
     draw_arrays(TRIANGLE_STRIP, 0, 4);
     bind_texture(TEXTURE_2D, 0);
 }
@@ -257,11 +312,17 @@ pub fn bind_and_render_quad(render_context: RenderContext, texture: GLuint) {
 // Layer rendering
 
 pub trait Render {
-    fn render(@mut self, render_context: RenderContext, transform: Matrix4<f32>);
+    fn render(@mut self,
+              render_context: RenderContext,
+              transform: Matrix4<f32>,
+              scene_size: Size2D<f32>);
 }
 
 impl Render for layers::ContainerLayer {
-    fn render(@mut self, render_context: RenderContext, transform: Matrix4<f32>) {
+    fn render(@mut self,
+              render_context: RenderContext,
+              transform: Matrix4<f32>,
+              scene_size: Size2D<f32>) {
         let old_rect_opt = if is_enabled(SCISSOR_TEST) {
             let mut old_rect = [0 as GLint, ..4];
             get_integer_v(SCISSOR_BOX, old_rect);
@@ -282,8 +343,8 @@ impl Render for layers::ContainerLayer {
                 let w_height = viewport[3];
                 let origin = Point2D((rect.origin.x * transform.m11 + transform.m41) as GLint,
                                      w_height
-                                     - ((rect.origin.y * transform.m22 + transform.m42) as GLint)
-                                     - size.height);                
+                                     -((rect.origin.y * transform.m22 + transform.m42) as GLint)
+                                     -size.height);                
                 let rect = Rect(origin, size);
                 
                 match old_rect_opt {
@@ -331,7 +392,7 @@ impl Render for layers::ContainerLayer {
 
         let transform = transform.mul(&self.common.transform);
         for child in self.children() {
-            render_layer(render_context, transform, child);
+            render_layer(render_context, transform, scene_size, child);
         }
         
         match (self.scissor, old_rect_opt) {
@@ -351,58 +412,25 @@ impl Render for layers::ContainerLayer {
 }
 
 impl Render for layers::TextureLayer {
-    fn render(@mut self, render_context: RenderContext, transform: Matrix4<f32>) {
+    fn render(@mut self,
+              render_context: RenderContext,
+              transform: Matrix4<f32>,
+              scene_size: Size2D<f32>) {
         let transform = transform.mul(&self.common.transform);
-        uniform_matrix_4fv(render_context.modelview_uniform, false, transform.to_array());
-
-        bind_and_render_quad(render_context, self.manager.get_texture());
+        bind_and_render_quad(render_context, &self.texture, self.flip, &transform, scene_size);
     }
 }
 
-impl Render for layers::ImageLayer {
-    fn render(@mut self, render_context: RenderContext, transform: Matrix4<f32>) {
-        create_texture_for_image_if_necessary(self.image);
-
-        let transform = transform.mul(&self.common.transform);
-        uniform_matrix_4fv(render_context.modelview_uniform, false, transform.to_array());
-        bind_and_render_quad(render_context, self.image.texture.unwrap());
-    }
-}
-
-impl Render for layers::TiledImageLayer {
-    fn render(@mut self, render_context: RenderContext, transform: Matrix4<f32>) {
-        let tiles_down = self.tiles.len() / self.tiles_across;
-        for (i, tile) in (*self.tiles).iter().enumerate() {
-            create_texture_for_image_if_necessary(*tile);
-
-            let x = ((i % self.tiles_across) as f32);
-            let y = ((i / self.tiles_across) as f32);
-
-            let transform = transform.mul(&self.common.transform);
-            let transform = transform.scale(1.0 / (self.tiles_across as f32),
-                                            1.0 / (tiles_down as f32),
-                                            1.0);
-            let transform = transform.translate(x, y, 0.0);
-
-            uniform_matrix_4fv(render_context.modelview_uniform, false, transform.to_array());
-            bind_and_render_quad(render_context, tile.texture.unwrap());
-        }
-    }
-}
-
-fn render_layer(render_context: RenderContext, transform: Matrix4<f32>, layer: layers::Layer) {
+fn render_layer(render_context: RenderContext,
+                transform: Matrix4<f32>,
+                scene_size: Size2D<f32>,
+                layer: layers::Layer) {
     match layer {
         ContainerLayerKind(container_layer) => {
-            container_layer.render(render_context, transform);
+            container_layer.render(render_context, transform, scene_size)
         }
         TextureLayerKind(texture_layer) => {
-            texture_layer.render(render_context, transform);
-        }
-        ImageLayerKind(image_layer) => {
-            image_layer.render(render_context, transform);
-        }
-        TiledImageLayerKind(tiled_image_layer) => {
-            tiled_image_layer.render(render_context, transform);
+            texture_layer.render(render_context, transform, scene_size)
         }
     }
 }
@@ -415,15 +443,11 @@ pub fn render_scene(render_context: RenderContext, scene: &Scene) {
     clear_color(0.38f32, 0.36f32, 0.36f32, 1.0f32);
     clear(COLOR_BUFFER_BIT);
 
-    // Set the projection matrix.
-    let projection_matrix = ortho(0.0, scene.size.width, scene.size.height, 0.0, -10.0, 10.0);
-    uniform_matrix_4fv(render_context.projection_uniform, false, projection_matrix.to_array());
-
     // Set up the initial modelview matrix.
     let transform = scene.transform;
 
     // Render the root layer.
-    render_layer(render_context, transform, scene.root);
+    render_layer(render_context, transform, scene.size, scene.root);
 }
 
 #[cfg(debug)]

--- a/texturegl.rs
+++ b/texturegl.rs
@@ -1,0 +1,180 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! OpenGL-specific implementation of texturing.
+
+use layers::{ARGB32Format, Format, RGB24Format};
+
+use geom::size::Size2D;
+use opengles::gl2::{BGRA, CLAMP_TO_EDGE, GLenum, GLint, GLsizei, GLuint, LINEAR, RGB, RGBA};
+use opengles::gl2::{TEXTURE_MAG_FILTER, TEXTURE_MIN_FILTER, TEXTURE_2D, TEXTURE_RECTANGLE_ARB};
+use opengles::gl2::{TEXTURE_WRAP_S, TEXTURE_WRAP_T, UNSIGNED_BYTE, UNSIGNED_INT_8_8_8_8_REV};
+use opengles::gl2;
+use std::num::Zero;
+
+/// Image data used when uploading to a texture.
+pub struct TextureImageData<'self> {
+    size: Size2D<uint>,
+    stride: uint,
+    format: Format,
+    data: &'self [u8],
+}
+
+/// The texture target.
+pub enum TextureTarget {
+    /// TEXTURE_2D.
+    TextureTarget2D,
+    /// TEXTURE_RECTANGLE_ARB, with the size included.
+    TextureTargetRectangle(Size2D<uint>),
+}
+
+impl TextureTarget {
+    fn as_gl_target(self) -> GLenum {
+        match self {
+            TextureTarget2D => TEXTURE_2D,
+            TextureTargetRectangle(*) => TEXTURE_RECTANGLE_ARB,
+        }
+    }
+}
+
+/// A texture.
+///
+/// TODO: Include client storage here for `GL_CLIENT_STORAGE_APPLE`.
+pub struct Texture {
+    /// The OpenGL texture ID.
+    priv id: GLuint,
+    /// The texture target.
+    target: TextureTarget,
+    /// Whether this texture is weak. Weak textures will not be cleaned up by
+    /// the destructor.
+    priv weak: bool,
+}
+
+impl Drop for Texture {
+    fn drop(&mut self) {
+        if !self.weak {
+            gl2::delete_textures([ self.id ])
+        }
+    }
+}
+
+impl Zero for Texture {
+    fn zero() -> Texture {
+        Texture {
+            id: 0,
+            target: TextureTarget2D,
+            weak: true,
+        }
+    }
+    fn is_zero(&self) -> bool {
+        self.id == 0
+    }
+}
+
+/// Encapsulates a bound texture. This ensures that the texture is unbound
+/// properly.
+struct BoundTexture {
+    target: TextureTarget
+}
+
+impl Drop for BoundTexture {
+    fn drop(&mut self) {
+        gl2::bind_texture(self.target.as_gl_target(), 0)
+    }
+}
+
+impl Texture {
+    /// Creates a new blank texture.
+    pub fn new(target: TextureTarget) -> Texture {
+        let this = Texture {
+            id: gl2::gen_textures(1)[0],
+            target: target,
+            weak: false,
+        };
+        this.set_default_params();
+        this
+    }
+
+    /// Creates a texture from an existing OpenGL texture. The texture will be deleted when this
+    /// `Texture` object goes out of scope.
+    pub fn adopt_native_texture(native_texture_id: GLuint, target: TextureTarget) -> Texture {
+        let this = Texture {
+            id: native_texture_id,
+            target: target,
+            weak: false,
+        };
+        this
+    }
+
+    /// Creates a texture from an existing OpenGL texture. The texture will *not* be deleted when
+    /// this `Texture` object goes out of scope.
+    pub fn wrap_native_texture(native_texture_id: GLuint, target: TextureTarget) -> Texture {
+        let this = Texture {
+            id: native_texture_id,
+            target: target,
+            weak: true,
+        };
+        this.set_default_params();
+        this
+    }
+
+    /// Returns the raw OpenGL texture underlying this texture.
+    pub fn native_texture(&self) -> GLuint {
+        self.id
+    }
+
+    /// Sets default parameters for this texture.
+    fn set_default_params(&self) {
+        let _bound_texture = self.bind();
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_MAG_FILTER, LINEAR as GLint);
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_MIN_FILTER, LINEAR as GLint);
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_WRAP_S, CLAMP_TO_EDGE as GLint);
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_WRAP_T, CLAMP_TO_EDGE as GLint);
+    }
+
+    /// Binds the texture to the current context.
+    pub fn bind(&self) -> BoundTexture {
+        gl2::bind_texture(self.target.as_gl_target(), self.id);
+
+        BoundTexture {
+            target: self.target,
+        }
+    }
+
+    /// Uploads raw image data to the texture.
+    pub fn upload_image<'a>(&self, texture_image_data: &TextureImageData<'a>) {
+        let _bound_texture = self.bind();
+
+        match texture_image_data.format {
+            RGB24Format => {
+                gl2::tex_image_2d(self.target.as_gl_target(),
+                                  0,
+                                  RGB as GLint,
+                                  texture_image_data.size.width as GLsizei,
+                                  texture_image_data.size.height as GLsizei,
+                                  0,
+                                  RGB,
+                                  UNSIGNED_BYTE,
+                                  Some(texture_image_data.data))
+            }
+            ARGB32Format => {
+                gl2::tex_image_2d(self.target.as_gl_target(),
+                                  0,
+                                  RGBA as GLint,
+                                  texture_image_data.size.width as GLsizei,
+                                  texture_image_data.size.height as GLsizei,
+                                  0,
+                                  BGRA,
+                                  UNSIGNED_INT_8_8_8_8_REV,
+                                  Some(texture_image_data.data))
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Also add support for both GL_TEXTURE_2D and GL_TEXTURE_RECTANGLE_ARB. The
latter is needed for cross-process surface support on Mac.
