### PR TITLE
fixes #34

### DIFF
--- a/color.rs
+++ b/color.rs
@@ -1,0 +1,15 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+pub struct Color {
+  r: f32,
+  g: f32,
+  b: f32,
+  a: f32
+}

--- a/lib.rs
+++ b/lib.rs
@@ -23,6 +23,7 @@ extern mod io_surface = "rust-io-surface";
 extern mod xlib = "rust-xlib";
 
 pub mod layers;
+pub mod color;
 pub mod rendergl;
 pub mod scene;
 pub mod texturegl;

--- a/rendergl.rs
+++ b/rendergl.rs
@@ -440,7 +440,10 @@ pub fn render_scene(render_context: RenderContext, scene: &Scene) {
     viewport(0 as GLint, 0 as GLint, scene.size.width as GLsizei, scene.size.height as GLsizei);
 
     // Clear the screen.
-    clear_color(0.38f32, 0.36f32, 0.36f32, 1.0f32);
+    clear_color(scene.background_color.r,
+                scene.background_color.g,
+                scene.background_color.b,
+                scene.background_color.a);
     clear(COLOR_BUFFER_BIT);
 
     // Set up the initial modelview matrix.

--- a/scene.rs
+++ b/scene.rs
@@ -8,20 +8,28 @@
 // except according to those terms.
 
 use layers::Layer;
+use color::Color;
 use geom::size::Size2D;
 use geom::matrix::Matrix4;
 
 pub struct Scene {
     root: Layer,
     size: Size2D<f32>,
-    transform: Matrix4<f32>
+    transform: Matrix4<f32>,
+    background_color: Color
 }
 
 pub fn Scene(root: Layer, size: Size2D<f32>, transform: Matrix4<f32>) -> Scene {
     Scene {
         root: root,
         size: size,
-        transform: transform
+        transform: transform,
+        background_color: Color {
+                  r: 0.38f32,
+                  g: 0.36f32,
+                  b: 0.36f32,
+                  a: 1.0f32
+              }
     }
 }
 


### PR DESCRIPTION
  Added background color attributes to scene

Shouldn't break servo's master branch, but allows for colors to be set for the scene.
