### PR TITLE
Use GLXFBConfig's depth when creating an XPixmap for a GLXPixmap

### DIFF
--- a/platform/linux/surface.rs
+++ b/platform/linux/surface.rs
@@ -208,7 +208,7 @@ impl NativeSurfaceMethods for NativeSurface {
                                        window,
                                        size.width as c_uint,
                                        size.height as c_uint,
-                                       ((stride / size.width) * 8) as c_uint);
+                                       (*native_context.visual_info).depth as c_uint);
             NativeSurface::from_pixmap(pixmap)
         }
     }


### PR DESCRIPTION
When creating a GLXPixmap we use an RGBA GLXFBConfig.  When creating the
XPixmap for that GLXPixmap we should use the depth from the XVisual
associated with that framebuffer configuration, as it might be 24 or 32.

Fixes #62.
