### PR TITLE
Update to latest Rust

### DIFF
--- a/layers.rs
+++ b/layers.rs
@@ -210,7 +210,7 @@ impl ContainerLayer {
 }
 
 /// Whether a texture should be flipped.
-#[deriving(Eq)]
+#[deriving(PartialEq)]
 pub enum Flip {
     /// The texture should not be flipped.
     NoFlip,

--- a/lib.rs
+++ b/lib.rs
@@ -16,7 +16,7 @@
 
 extern crate geom;
 extern crate libc;
-#[phase(syntax, link)]
+#[phase(plugin, link)]
 extern crate log;
 extern crate opengles;
 extern crate std;

--- a/platform/linux/surface.rs
+++ b/platform/linux/surface.rs
@@ -180,7 +180,7 @@ impl NativeGraphicsMetadataDescriptor {
     }
 }
 
-#[deriving(Eq)]
+#[deriving(PartialEq)]
 pub enum NativeSurfaceTransientData {
     NoTransientData,
     RenderTaskTransientData(*Display, *XVisualInfo),


### PR DESCRIPTION
Brings us to [`9f8d2205f0518389993a9b5de6646ba8b14e5a12`](https://github.com/rust-lang/rust/tree/9f8d2205f0518389993a9b5de6646ba8b14e5a12) (June 17)

See https://github.com/mozilla/servo/pull/2677
