### PR TITLE
Convert static Layer methods into instance methods

### DIFF
--- a/layers.rs
+++ b/layers.rs
@@ -27,7 +27,7 @@ pub struct Layer<T> {
     pub tiles: RefCell<Vec<Rc<TextureLayer>>>,
     pub transform: RefCell<Matrix4<f32>>,
     pub bounds: RefCell<Rect<f32>>,
-    tile_size: uint,
+    pub tile_size: uint,
     pub extra_data: RefCell<T>,
     tile_grid: RefCell<TileGrid>,
 }
@@ -49,37 +49,33 @@ impl<T> Layer<T> {
         self.children.borrow_mut()
     }
 
-    pub fn add_child(this: Rc<Layer<T>>, new_child: Rc<Layer<T>>) {
-        this.children().push(new_child);
+    pub fn add_child(&self, new_child: Rc<Layer<T>>) {
+        self.children().push(new_child);
     }
 
-    pub fn tile_size(this: Rc<Layer<T>>) -> uint {
-        this.tile_size
-    }
-
-    pub fn get_tile_rects_page(this: Rc<Layer<T>>, window: Rect<f32>, scale: f32) -> (Vec<BufferRequest>, Vec<Box<LayerBuffer>>) {
-        let mut tile_grid = this.tile_grid.borrow_mut();
+    pub fn get_tile_rects_page(&self, window: Rect<f32>, scale: f32) -> (Vec<BufferRequest>, Vec<Box<LayerBuffer>>) {
+        let mut tile_grid = self.tile_grid.borrow_mut();
         (tile_grid.get_buffer_requests_in_rect(window, scale), tile_grid.take_unused_tiles())
     }
 
-    pub fn resize(this: Rc<Layer<T>>, new_size: Size2D<f32>) {
-        this.bounds.borrow_mut().size = new_size;
+    pub fn resize(&self, new_size: Size2D<f32>) {
+        self.bounds.borrow_mut().size = new_size;
     }
 
-    pub fn do_for_all_tiles(this: Rc<Layer<T>>, f: |&Box<LayerBuffer>|) {
-        this.tile_grid.borrow().do_for_all_tiles(f);
+    pub fn do_for_all_tiles(&self, f: |&Box<LayerBuffer>|) {
+        self.tile_grid.borrow().do_for_all_tiles(f);
     }
 
-    pub fn add_tile_pixel(this: Rc<Layer<T>>, tile: Box<LayerBuffer>) {
-        this.tile_grid.borrow_mut().add_tile(tile);
+    pub fn add_tile_pixel(&self, tile: Box<LayerBuffer>) {
+        self.tile_grid.borrow_mut().add_tile(tile);
     }
 
-    pub fn collect_unused_tiles(this: Rc<Layer<T>>) -> Vec<Box<LayerBuffer>> {
-        this.tile_grid.borrow_mut().take_unused_tiles()
+    pub fn collect_unused_tiles(&self) -> Vec<Box<LayerBuffer>> {
+        self.tile_grid.borrow_mut().take_unused_tiles()
     }
 
-    pub fn collect_tiles(this: Rc<Layer<T>>) -> Vec<Box<LayerBuffer>> {
-        this.tile_grid.borrow_mut().collect_tiles()
+    pub fn collect_tiles(&self) -> Vec<Box<LayerBuffer>> {
+        self.tile_grid.borrow_mut().collect_tiles()
     }
 
     pub fn flush_pending_buffer_requests(&self) -> (Vec<BufferRequest>, f32) {


### PR DESCRIPTION
It is possible to call methods directly on types contained in Rc<...>
containers, so these methods do not have to be static.
