### PR TITLE
Tile cleanup

### DIFF
--- a/rendergl.rs
+++ b/rendergl.rs
@@ -7,11 +7,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use layers::{Layer, TextureLayer};
+use layers::Layer;
 use layers;
 use scene::Scene;
 use texturegl::{Flip, NoFlip, VerticalFlip};
 use texturegl::{Texture, TextureTarget2D, TextureTargetRectangle};
+use tiling::Tile;
 
 use geom::matrix::{Matrix4, ortho};
 use geom::size::Size2D;
@@ -369,16 +370,18 @@ impl<T> Render for layers::Layer<T> {
               scene_size: Size2D<f32>) {
         let origin = self.bounds.borrow().origin;
         let transform = transform.translate(origin.x, origin.y, 0.0).mul(&*self.transform.borrow());
-        for tile in self.tiles.borrow().iter() {
+
+        self.do_for_all_tiles(|tile: &Tile| {
             tile.render(render_context, transform, scene_size)
-        }
+        });
+
         for child in self.children().iter() {
             child.render(render_context, transform, scene_size)
         }
     }
 }
 
-impl Render for layers::TextureLayer {
+impl Render for Tile {
     fn render(&self,
               render_context: RenderContext,
               transform: Matrix4<f32>,

--- a/texturegl.rs
+++ b/texturegl.rs
@@ -9,7 +9,7 @@
 
 //! OpenGL-specific implementation of texturing.
 
-use layers::{ARGB32Format, Format, RGB24Format, LayerBuffer};
+use layers::LayerBuffer;
 
 use geom::size::Size2D;
 use opengles::gl2::{BGRA, CLAMP_TO_EDGE, GLenum, GLint, GLsizei, GLuint, LINEAR, RGB, RGBA};
@@ -17,6 +17,11 @@ use opengles::gl2::{TEXTURE_MAG_FILTER, TEXTURE_MIN_FILTER, TEXTURE_2D, TEXTURE_
 use opengles::gl2::{TEXTURE_WRAP_S, TEXTURE_WRAP_T, UNSIGNED_BYTE, UNSIGNED_INT_8_8_8_8_REV};
 use opengles::gl2;
 use std::num::Zero;
+
+pub enum Format {
+    ARGB32Format,
+    RGB24Format
+}
 
 /// Image data used when uploading to a texture.
 pub struct TextureImageData<'a> {


### PR DESCRIPTION
Tiles textures are maintained inside the TileGrid alongside buffers and Servo is no longer involved in the creation of Textures.
