### PR TITLE
Change texture creation to use nearest filtering. Fixes several reftests

### DIFF
--- a/rendergl.rs
+++ b/rendergl.rs
@@ -11,7 +11,7 @@ use color::Color;
 use layers::Layer;
 use layers;
 use scene::Scene;
-use texturegl::{Flip, NoFlip, VerticalFlip};
+use texturegl::{Flip, Linear, Nearest, NoFlip, VerticalFlip};
 use texturegl::{Texture, TextureTarget2D, TextureTargetRectangle};
 use tiling::Tile;
 use platform::surface::NativeCompositingGraphicsContext;
@@ -415,6 +415,18 @@ pub fn bind_and_render_quad(render_context: RenderContext,
 
     use_program(program_id);
     active_texture(TEXTURE0);
+
+    // FIXME: This should technically check that the transform
+    // matrix only contains scale in these components.
+    let has_scale = transform.m11 as uint != texture.size.width ||
+                    transform.m22 as uint != texture.size.height;
+    let filter_mode = if has_scale {
+        Linear
+    } else {
+        Nearest
+    };
+    texture.set_filter_mode(filter_mode);
+
     let _bound_texture = texture.bind();
 
     // Set the projection matrix.
@@ -530,7 +542,8 @@ impl Render for Tile {
     }
 }
 
-pub fn render_scene<T>(root_layer: Rc<Layer<T>>, render_context: RenderContext, scene: &Scene<T>) {
+pub fn render_scene<T>(root_layer: Rc<Layer<T>>, render_context: RenderContext,
+                        scene: &Scene<T>) {
     // Set the viewport.
     viewport(0 as GLint, 0 as GLint, scene.size.width as GLsizei, scene.size.height as GLsizei);
 

--- a/texturegl.rs
+++ b/texturegl.rs
@@ -12,7 +12,7 @@
 use layers::LayerBuffer;
 
 use geom::size::Size2D;
-use opengles::gl2::{BGRA, CLAMP_TO_EDGE, GLenum, GLint, GLsizei, GLuint, LINEAR, RGB, RGBA};
+use opengles::gl2::{BGRA, CLAMP_TO_EDGE, GLenum, GLint, GLsizei, GLuint, LINEAR, NEAREST, RGB, RGBA};
 use opengles::gl2::{TEXTURE_MAG_FILTER, TEXTURE_MIN_FILTER, TEXTURE_2D, TEXTURE_RECTANGLE_ARB};
 use opengles::gl2::{TEXTURE_WRAP_S, TEXTURE_WRAP_T, UNSIGNED_BYTE, UNSIGNED_INT_8_8_8_8_REV};
 use opengles::gl2;
@@ -21,6 +21,11 @@ use std::num::Zero;
 pub enum Format {
     ARGB32Format,
     RGB24Format
+}
+
+pub enum FilterMode {
+    Nearest,
+    Linear
 }
 
 /// Image data used when uploading to a texture.
@@ -173,6 +178,17 @@ impl Texture {
         gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_MIN_FILTER, LINEAR as GLint);
         gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_WRAP_S, CLAMP_TO_EDGE as GLint);
         gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_WRAP_T, CLAMP_TO_EDGE as GLint);
+    }
+
+    /// Sets the filter mode for this texture.
+    pub fn set_filter_mode(&self, mode: FilterMode) {
+        let _bound_texture = self.bind();
+        let gl_mode = match mode {
+            Nearest => NEAREST,
+            Linear => LINEAR,
+        } as GLint;
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_MAG_FILTER, gl_mode);
+        gl2::tex_parameter_i(self.target.as_gl_target(), TEXTURE_MIN_FILTER, gl_mode);
     }
 
     /// Binds the texture to the current context.


### PR DESCRIPTION
due to the different texture sizes that are created now with the removal
of the quadtree code.
