### PR TITLE
Store content offset in unscaled pixels

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -12,7 +12,7 @@ use tiling::{Tile, TileGrid};
 
 use geom::matrix::{Matrix4, identity};
 use geom::size::{Size2D, TypedSize2D};
-use geom::point::TypedPoint2D;
+use geom::point::Point2D;
 use geom::rect::{Rect, TypedRect};
 use platform::surface::{NativeSurfaceMethods, NativeSurface};
 use platform::surface::{NativeCompositingGraphicsContext, NativePaintingGraphicsContext};
@@ -49,8 +49,8 @@ pub struct Layer<T> {
     /// A monotonically increasing counter that keeps track of the current content age.
     pub content_age: RefCell<ContentAge>,
 
-    /// The content offset for this layer in device pixels.
-    pub content_offset: RefCell<TypedPoint2D<DevicePixel, f32>>,
+    /// The content offset for this layer in unscaled layer pixels.
+    pub content_offset: RefCell<Point2D<f32>>,
 }
 
 impl<T> Layer<T> {
@@ -63,7 +63,7 @@ impl<T> Layer<T> {
             extra_data: RefCell::new(data),
             tile_grid: RefCell::new(TileGrid::new(tile_size)),
             content_age: RefCell::new(ContentAge::new()),
-            content_offset: RefCell::new(TypedPoint2D(0f32, 0f32)),
+            content_offset: RefCell::new(Point2D(0f32, 0f32)),
         }
     }
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -16,7 +16,7 @@ use texturegl::{Texture, TextureTarget2D, TextureTargetRectangle};
 use tiling::Tile;
 use platform::surface::NativeCompositingGraphicsContext;
 
-use geom::matrix::{Matrix4, ortho};
+use geom::matrix::{Matrix4, identity, ortho};
 use geom::size::Size2D;
 use libc::c_int;
 use opengles::gl2::{ARRAY_BUFFER, BLEND, COLOR_BUFFER_BIT, COMPILE_STATUS, FRAGMENT_SHADER};
@@ -496,12 +496,12 @@ impl<T> Render for layers::Layer<T> {
               transform: Matrix4<f32>,
               scene_size: Size2D<f32>) {
         let bounds = self.bounds.borrow().to_untyped();
-        let transform = transform.translate(bounds.origin.x, bounds.origin.y, 0.0)
-            .mul(&*self.transform.borrow());
+        let cumulative_transform = transform.translate(bounds.origin.x, bounds.origin.y, 0.0);
+        let tile_transform = cumulative_transform.mul(&*self.transform.borrow());
 
         self.create_textures(&render_context.compositing_context);
         self.do_for_all_tiles(|tile: &Tile| {
-            tile.render(render_context, transform, scene_size)
+            tile.render(render_context, tile_transform, scene_size)
         });
 
         if render_context.show_debug_borders {
@@ -514,7 +514,7 @@ impl<T> Render for layers::Layer<T> {
         }
 
         for child in self.children().iter() {
-            child.render(render_context, transform, scene_size)
+            child.render(render_context, cumulative_transform, scene_size)
         }
 
     }
@@ -542,8 +542,9 @@ impl Render for Tile {
     }
 }
 
-pub fn render_scene<T>(root_layer: Rc<Layer<T>>, render_context: RenderContext,
-                        scene: &Scene<T>) {
+pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
+                       render_context: RenderContext,
+                       scene: &Scene<T>) {
     // Set the viewport.
     viewport(0 as GLint, 0 as GLint, scene.size.width as GLsizei, scene.size.height as GLsizei);
 
@@ -555,7 +556,7 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>, render_context: RenderContext,
     clear(COLOR_BUFFER_BIT);
 
     // Set up the initial modelview matrix.
-    let transform = scene.transform;
+    let transform = identity().scale(scene.scale, scene.scale, 1.0);
 
     // Render the root layer.
     root_layer.render(render_context, transform, scene.size);


### PR DESCRIPTION
This is necessary because the renderer pre-scales the scene when
applying content offset. We also store a scene scale instead of a scene
transformation, so that we know how to properly deal with device pixels.
Also ensures that content offset is not accumulated when rendering
layers.
