### PR TITLE
Allow layers to mask children to their boundaries

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -51,6 +51,9 @@ pub struct Layer<T> {
 
     /// The content offset for this layer in unscaled layer pixels.
     pub content_offset: RefCell<Point2D<f32>>,
+
+    /// Whether this layer clips its children to its boundaries.
+    pub masks_to_bounds: RefCell<bool>,
 }
 
 impl<T> Layer<T> {
@@ -63,6 +66,7 @@ impl<T> Layer<T> {
             extra_data: RefCell::new(data),
             tile_grid: RefCell::new(TileGrid::new(tile_size)),
             content_age: RefCell::new(ContentAge::new()),
+            masks_to_bounds: RefCell::new(false),
             content_offset: RefCell::new(Point2D(0f32, 0f32)),
         }
     }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -35,6 +35,9 @@ pub struct Tile {
 
     /// The transformation applied to this tiles texture.
     pub transform: Matrix4<f32>,
+
+    /// The tile boundaries in the parent layer coordinates.
+    pub bounds: Option<Rect<f32>>,
 }
 
 impl Tile {
@@ -44,6 +47,7 @@ impl Tile {
             texture: Zero::zero(),
             transform: identity(),
             content_age_of_pending_buffer: None,
+            bounds: None,
         }
     }
 
@@ -88,6 +92,7 @@ impl Tile {
                 let rect = buffer.rect;
                 let transform = identity().translate(rect.origin.x, rect.origin.y, 0.0);
                 self.transform = transform.scale(rect.size.width, rect.size.height, 1.0);
+                self.bounds = Some(rect);
             },
             None => {},
         }


### PR DESCRIPTION
This allows preventing iframes from overlowing their boundaries. We
also ensure that buffer requests are made for child layers, even when
their parents don't overlap the window rect. This is because children
can lie completely outside the bounds of their parents.
