### PR TITLE
Allow scene to specify its GL viewport

### DIFF
--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -529,7 +529,9 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
                        render_context: RenderContext,
                        scene: &Scene<T>) {
     // Set the viewport.
-    viewport(0 as GLint, 0 as GLint, scene.size.width as GLsizei, scene.size.height as GLsizei);
+    let v = scene.viewport.to_untyped();
+    viewport(v.origin.x as GLint, v.origin.y as GLint,
+             v.size.width as GLsizei, v.size.height as GLsizei);
 
     // Clear the screen.
     clear_color(scene.background_color.r,
@@ -542,5 +544,6 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
     let transform = identity().scale(scene.scale, scene.scale, 1.0);
 
     // Render the root layer.
-    root_layer.render(render_context, transform, scene.size, None, Point2D(0., 0.));
+    root_layer.render(render_context, transform, scene.viewport.size.to_untyped(), None,
+                      Point2D(0., 0.));
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -11,7 +11,7 @@ use color::Color;
 use geom::matrix::Matrix4;
 use geom::point::Point2D;
 use geom::rect::{Rect, TypedRect};
-use geom::size::{Size2D, TypedSize2D};
+use geom::size::TypedSize2D;
 use geometry::DevicePixel;
 use layers::{BufferRequest, Layer, LayerBuffer};
 use std::mem;
@@ -20,7 +20,7 @@ use std::rc::Rc;
 
 pub struct Scene<T> {
     pub root: Option<Rc<Layer<T>>>,
-    pub size: Size2D<f32>,
+    pub viewport: TypedRect<DevicePixel, f32>,
     pub background_color: Color,
     pub unused_buffers: Vec<Box<LayerBuffer>>,
 
@@ -29,10 +29,10 @@ pub struct Scene<T> {
 }
 
 impl<T> Scene<T> {
-    pub fn new(size: Size2D<f32>) -> Scene<T> {
+    pub fn new(viewport: TypedRect<DevicePixel, f32>) -> Scene<T> {
         Scene {
             root: None,
-            size: size,
+            viewport: viewport,
             background_color: Color {
                 r: 0.38f32,
                 g: 0.36f32,


### PR DESCRIPTION
This is intended for use by applications that embed a Servo view as a widget
within one part of a window.

Requires a Servo change which I'll file as a separate PR.

r? @zwarich
