### PR TITLE
Allow layers to paint their own background colors

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -7,6 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use color::Color;
 use geometry::{DevicePixel, LayerPixel};
 use tiling::{Tile, TileGrid};
 
@@ -56,10 +57,17 @@ pub struct Layer<T> {
 
     /// Whether this layer clips its children to its boundaries.
     pub masks_to_bounds: RefCell<bool>,
+
+    /// The background color for this layer.
+    pub background_color: RefCell<Color>,
 }
 
 impl<T> Layer<T> {
-    pub fn new(bounds: TypedRect<LayerPixel, f32>, tile_size: uint, data: T) -> Layer<T> {
+    pub fn new(bounds: TypedRect<LayerPixel, f32>,
+               tile_size: uint,
+               background_color: Color,
+               data: T)
+               -> Layer<T> {
         Layer {
             children: RefCell::new(vec!()),
             transform: RefCell::new(identity()),
@@ -70,6 +78,7 @@ impl<T> Layer<T> {
             content_age: RefCell::new(ContentAge::new()),
             masks_to_bounds: RefCell::new(false),
             content_offset: RefCell::new(Zero::zero()),
+            background_color: RefCell::new(background_color),
         }
     }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -22,7 +22,6 @@ use std::rc::Rc;
 pub struct Scene<T> {
     pub root: Option<Rc<Layer<T>>>,
     pub viewport: TypedRect<DevicePixel, f32>,
-    pub background_color: Color,
     pub unused_buffers: Vec<Box<LayerBuffer>>,
 
     /// The scene scale, to allow for zooming and high-resolution painting.
@@ -34,12 +33,6 @@ impl<T> Scene<T> {
         Scene {
             root: None,
             viewport: viewport,
-            background_color: Color {
-                r: 0.38f32,
-                g: 0.36f32,
-                b: 0.36f32,
-                a: 1.0f32
-            },
             unused_buffers: Vec::new(),
             scale: ScaleFactor(1.0),
         }


### PR DESCRIPTION
Previously there was only a scene-wide background color, but now each
layer carries its own background color. We can paint this by
generalizing the SolidLineProgram in the OpenGL renderer.
