### PR TITLE
Introduce LayerPixel and use it where applicable

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -15,4 +15,11 @@
 #[deriving(Encodable)]
 pub enum DevicePixel {}
 
+/// One pixel in layer coordinate space.
+///
+/// This unit corresponds to a "pixel" in layer coordinate space, which after scaling and
+/// transformation becomes a device pixel.
+#[deriving(Encodable)]
+pub enum LayerPixel {}
+
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -442,7 +442,7 @@ impl<T> Render for layers::Layer<T> {
         let bounds = self.bounds.borrow().to_untyped();
         let cumulative_transform = transform.translate(bounds.origin.x, bounds.origin.y, 0.0);
         let tile_transform = cumulative_transform.mul(&*self.transform.borrow());
-        let content_offset = *self.content_offset.borrow();
+        let content_offset = self.content_offset.borrow().to_untyped();
 
         self.create_textures(&render_context.compositing_context);
         self.do_for_all_tiles(|tile: &Tile| {
@@ -499,7 +499,7 @@ impl Render for Tile {
         }
 
         let bounds = match self.bounds {
-            Some(ref bounds) => bounds.translate(&content_offset),
+            Some(ref bounds) => bounds.to_untyped().translate(&content_offset),
             None => return,
         };
 
@@ -541,7 +541,7 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
     clear(COLOR_BUFFER_BIT);
 
     // Set up the initial modelview matrix.
-    let transform = identity().scale(scene.scale, scene.scale, 1.0);
+    let transform = identity().scale(scene.scale.get(), scene.scale.get(), 1.0);
 
     // Render the root layer.
     root_layer.render(render_context, transform, scene.viewport.size.to_untyped(), None,

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use geometry::DevicePixel;
+use geometry::{DevicePixel, LayerPixel};
 use layers::{BufferRequest, ContentAge, LayerBuffer};
 use platform::surface::{NativeCompositingGraphicsContext, NativeSurfaceMethods};
 use texturegl::Texture;
@@ -37,7 +37,7 @@ pub struct Tile {
     pub transform: Matrix4<f32>,
 
     /// The tile boundaries in the parent layer coordinates.
-    pub bounds: Option<Rect<f32>>,
+    pub bounds: Option<TypedRect<LayerPixel,f32>>,
 }
 
 impl Tile {
@@ -92,7 +92,7 @@ impl Tile {
                 let rect = buffer.rect;
                 let transform = identity().translate(rect.origin.x, rect.origin.y, 0.0);
                 self.transform = transform.scale(rect.size.width, rect.size.height, 1.0);
-                self.bounds = Some(rect);
+                self.bounds = Some(Rect::from_untyped(&rect));
             },
             None => {},
         }


### PR DESCRIPTION
LayerPixel represents a "pixel" in layer coordinates, before it is
scaled by the Scene scale and other layer transforms. This is a much
more natural way to store layer sizes and should fix and prevent future
issues with hidpi displays and zoomed views.
