### PR TITLE
Avoid sending empty buffer requests

### DIFF
--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -216,6 +216,11 @@ impl TileGrid {
             Occupied(occupied) => occupied.into_mut(),
             Vacant(vacant) => vacant.set(Tile::new()),
         };
+
+        if tile_rect.is_empty() {
+            return None;
+        }
+
         if !tile.should_request_buffer(current_content_age) {
             return None;
         }


### PR DESCRIPTION
Empty buffer requests can trigger the render task to trying to create
empty platform surfaces, which is unsupported on some platforms.
Additionally, they can create unnecessary traffic between the
compositor and render task in Servo.
