### PR TITLE
Remove usage of the deprecated std::num::Zero trait.

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -14,12 +14,12 @@ use tiling::{Tile, TileGrid};
 use geom::matrix::{Matrix4, identity};
 use geom::scale_factor::ScaleFactor;
 use geom::size::{Size2D, TypedSize2D};
-use geom::point::{TypedPoint2D};
+use geom::point::{Point2D, TypedPoint2D};
 use geom::rect::{Rect, TypedRect};
 use platform::surface::{NativeSurfaceMethods, NativeSurface};
 use platform::surface::{NativeCompositingGraphicsContext, NativePaintingGraphicsContext};
 use std::cell::{RefCell, RefMut};
-use std::num::{Float, Zero};
+use std::num::Float;
 use std::rc::Rc;
 
 #[deriving(Clone, PartialEq, PartialOrd)]
@@ -77,7 +77,7 @@ impl<T> Layer<T> {
             tile_grid: RefCell::new(TileGrid::new(tile_size)),
             content_age: RefCell::new(ContentAge::new()),
             masks_to_bounds: RefCell::new(false),
-            content_offset: RefCell::new(Zero::zero()),
+            content_offset: RefCell::new(Point2D::zero()),
             background_color: RefCell::new(background_color),
         }
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -10,10 +10,10 @@
 use geom::rect::{Rect, TypedRect};
 use geom::scale_factor::ScaleFactor;
 use geom::size::TypedSize2D;
+use geom::point::Point2D;
 use geometry::{DevicePixel, LayerPixel};
 use layers::{BufferRequest, Layer, LayerBuffer};
 use std::mem;
-use std::num::Zero;
 use std::rc::Rc;
 
 pub struct Scene<T> {
@@ -130,7 +130,7 @@ impl<T> Scene<T> {
     pub fn set_root_layer_size(&self, new_size: TypedSize2D<DevicePixel, f32>) {
         match self.root {
             Some(ref root_layer) => {
-                *root_layer.bounds.borrow_mut() = Rect(Zero::zero(), new_size / self.scale);
+                *root_layer.bounds.borrow_mut() = Rect(Point2D::zero(), new_size / self.scale);
             },
             None => {},
         }

--- a/src/texturegl.rs
+++ b/src/texturegl.rs
@@ -14,7 +14,6 @@ use layers::LayerBuffer;
 use geom::size::Size2D;
 use gleam::gl;
 use gleam::gl::{GLenum, GLint, GLuint};
-use std::num::Zero;
 
 pub enum Format {
     ARGB32Format,
@@ -82,16 +81,8 @@ impl Drop for Texture {
     }
 }
 
-// This Trait is implemented because it is required
-// for Zero, but we should never call it on textures.
-impl Add<Texture, Texture> for Texture {
-    fn add(&self, _: &Texture) -> Texture {
-        panic!("Textures cannot be added.");
-    }
-}
-
-impl Zero for Texture {
-    fn zero() -> Texture {
+impl Texture {
+    pub fn zero() -> Texture {
         Texture {
             id: 0,
             target: TextureTarget::TextureTarget2D,
@@ -100,7 +91,7 @@ impl Zero for Texture {
             size: Size2D(0u, 0u),
         }
     }
-    fn is_zero(&self) -> bool {
+    pub fn is_zero(&self) -> bool {
         self.id == 0
     }
 }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::{Occupied, Vacant};
 use std::iter::range_inclusive;
 use std::mem;
-use std::num::{Float, FloatMath, Zero};
+use std::num::{Float, FloatMath};
 
 pub struct Tile {
     /// The buffer displayed by this tile.
@@ -45,7 +45,7 @@ impl Tile {
     fn new() -> Tile {
         Tile {
             buffer: None,
-            texture: Zero::zero(),
+            texture: Texture::zero(),
             transform: identity(),
             content_age_of_pending_buffer: None,
             bounds: None,
@@ -67,7 +67,7 @@ impl Tile {
 
         let old_buffer = self.buffer.take();
         self.buffer = Some(buffer);
-        self.texture = Zero::zero(); // The old texture is bound to the old buffer.
+        self.texture = Texture::zero(); // The old texture is bound to the old buffer.
         self.content_age_of_pending_buffer = None;
         return old_buffer;
     }


### PR DESCRIPTION
Requires https://github.com/servo/rust-geom/pull/59
