### PR TITLE
Use Azure's DrawTargetBacking and Skia directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ git = "https://github.com/servo/rust-cgl"
 [dependencies.gleam]
 git = "https://github.com/servo/gleam"
 
+[dependencies.skia]
+git = "https://github.com/servo/skia"
+
 [dependencies.azure]
 git = "https://github.com/servo/rust-azure"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ extern crate libc;
 extern crate log;
 extern crate "serialize" as rustc_serialize;
 extern crate gleam;
+extern crate skia;
 
 #[cfg(target_os="macos")]
 extern crate core_foundation;

--- a/src/platform/android/surface.rs
+++ b/src/platform/android/surface.rs
@@ -11,12 +11,12 @@
 
 use texturegl::Texture;
 
-use azure::AzSkiaGrGLSharedSurfaceRef;
 use geom::size::Size2D;
 use gleam::gl::{egl_image_target_texture2d_oes, TEXTURE_2D, TexImage2D, BGRA, UNSIGNED_BYTE};
 use egl::egl::EGLDisplay;
 use egl::eglext::{EGLImageKHR, DestroyImageKHR};
 use libc::c_void;
+use skia::{SkiaSkNativeSharedGLContextRef, SkiaSkNativeSharedGLContextStealSurface};
 use std::iter::repeat;
 use std::mem;
 use std::ptr;
@@ -77,8 +77,10 @@ impl EGLImageNativeSurface {
         }
     }
 
-    pub fn from_azure_surface(surface: AzSkiaGrGLSharedSurfaceRef) -> EGLImageNativeSurface {
+    pub fn from_skia_shared_gl_context(context: SkiaSkNativeSharedGLContextRef)
+                                       -> EGLImageNativeSurface {
         unsafe {
+            let surface = SkiaSkNativeSharedGLContextStealSurface(context);
             EGLImageNativeSurface::from_image_khr(mem::transmute(surface))
         }
     }

--- a/src/platform/linux/surface.rs
+++ b/src/platform/linux/surface.rs
@@ -13,11 +13,11 @@
 
 use texturegl::Texture;
 
-use azure::AzSkiaGrGLSharedSurfaceRef;
 use geom::size::Size2D;
 use libc::{c_char, c_int, c_uint, c_void};
 use glx;
 use gleam::gl;
+use skia::{SkiaSkNativeSharedGLContextRef, SkiaSkNativeSharedGLContextStealSurface};
 use std::ascii::{AsciiExt, OwnedAsciiExt};
 use std::ffi::{CString, c_str_to_bytes};
 use std::mem;
@@ -235,8 +235,10 @@ impl PixmapNativeSurface {
         }
     }
 
-    pub fn from_azure_surface(surface: AzSkiaGrGLSharedSurfaceRef) -> PixmapNativeSurface {
+    pub fn from_skia_shared_gl_context(context: SkiaSkNativeSharedGLContextRef)
+                                       -> PixmapNativeSurface {
         unsafe {
+            let surface = SkiaSkNativeSharedGLContextStealSurface(context);
             PixmapNativeSurface::from_pixmap(mem::transmute(surface))
         }
     }

--- a/src/platform/macos/surface.rs
+++ b/src/platform/macos/surface.rs
@@ -12,7 +12,6 @@
 
 use texturegl::Texture;
 
-use azure::AzSkiaGrGLSharedSurfaceRef;
 use core_foundation::base::TCFType;
 use core_foundation::boolean::CFBoolean;
 use core_foundation::dictionary::CFDictionary;
@@ -26,6 +25,7 @@ use cgl::{CGLChoosePixelFormat, CGLDescribePixelFormat, CGLPixelFormatAttribute}
 use cgl::{CGLPixelFormatObj, CORE_BOOLEAN_ATTRIBUTES, CORE_INTEGER_ATTRIBUTES};
 use cgl::{kCGLNoError};
 use gleam::gl::GLint;
+use skia::{SkiaSkNativeSharedGLContextRef, SkiaSkNativeSharedGLContextStealSurface};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem;
@@ -166,8 +166,10 @@ impl IOSurfaceNativeSurface {
         }
     }
 
-    pub fn from_azure_surface(surface: AzSkiaGrGLSharedSurfaceRef) -> IOSurfaceNativeSurface {
+    pub fn from_skia_shared_gl_context(context: SkiaSkNativeSharedGLContextRef)
+                                       -> IOSurfaceNativeSurface {
         unsafe {
+            let surface = SkiaSkNativeSharedGLContextStealSurface(context);
             let io_surface = IOSurface {
                 obj: mem::transmute(surface),
             };


### PR DESCRIPTION
Some Rust API has moved form rust-azure to Skia. Also allow creating a
native surface by consuming a DrawTargetBacking.  This will allow
rust-layers to work with different kinds of Azure surfaces.