### PR TITLE
Replace bytes when uploading to MemoryBufferNativeSurface

### DIFF
--- a/src/platform/surface.rs
+++ b/src/platform/surface.rs
@@ -221,6 +221,7 @@ impl MemoryBufferNativeSurface {
 
     /// This may only be called on the painting side.
     pub fn upload(&mut self, _: &NativePaintingGraphicsContext, data: &[u8]) {
+        self.bytes.clear();
         self.bytes.push_all(data);
     }
 


### PR DESCRIPTION
Instead of appending the bytes when uploading to
MemoryBufferNativeSurface, replace them. This fixes issues when calling
upload twice on the same buffer, which can happen if the buffers are
cached externally.