### PR TITLE
Properly specify the Skia branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ git = "https://github.com/servo/gleam"
 
 [dependencies.skia]
 git = "https://github.com/servo/skia"
+branch = "upstream-2014-06-16"
 
 [dependencies.azure]
 git = "https://github.com/servo/rust-azure"


### PR DESCRIPTION
This problem was hidden by the use of Cargo path overrides.