### PR TITLE
Clear the background to white before rendering the scene.

### DIFF
--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -586,6 +586,9 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
     gl::viewport(v.origin.x as GLint, v.origin.y as GLint,
                  v.size.width as GLsizei, v.size.height as GLsizei);
 
+    gl::clear_color(1.0, 1.0, 1.0, 1.0);
+    gl::clear(gl::COLOR_BUFFER_BIT);
+
     // Set up the initial modelview matrix.
     let transform = identity().scale(scene.scale.get(), scene.scale.get(), 1.0);
 


### PR DESCRIPTION
This means that we will be able to make layers use the correct "initial" value for background-color of transparent, which fixes specifying the background color for iframes.