### PR TITLE
Switch the dependency on x11 to be linux-only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,11 @@ git = "https://github.com/servo/rust-core-foundation"
 
 git = "https://github.com/servo/rust-io-surface"
 
-[dependencies.x11]
+[target.i686-unknown-linux-gnu.dependencies.x11]
+version = "1.0.1"
+features = ["xlib"]
 
+[target.x86_64-unknown-linux-gnu.dependencies.x11]
 version = "1.0.1"
 features = ["xlib"]
 


### PR DESCRIPTION
r? @glennw @metajack 

x11 cannot be cross-compiled (and wouldn't make any sense anyway, as it's not available on Android)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/164)
<!-- Reviewable:end -->
