### PR TITLE
Use autogenerated bindings for egl and glx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,6 @@ cgl = "0.1"
 [target.x86_64-apple-darwin.dependencies.io-surface]
 git = "https://github.com/servo/io-surface-rs"
 
-[target.i686-unknown-linux-gnu.dependencies.glx]
-git = "https://github.com/servo/rust-glx"
-
-[target.x86_64-unknown-linux-gnu.dependencies.glx]
-git = "https://github.com/servo/rust-glx"
-
-[target.arm-unknown-linux-gnueabihf.dependencies.glx]
-git = "https://github.com/servo/rust-glx"
-
 [target.i686-unknown-linux-gnu.dependencies.x11]
 version = "1.1.1"
 features = ["xlib"]
@@ -44,6 +35,15 @@ features = ["xlib"]
 [target.arm-unknown-linux-gnueabihf.dependencies.x11]
 version = "1.1.1"
 features = ["xlib"]
+
+[target.i686-unknown-linux-gnu.dependencies.glx]
+git = "https://github.com/servo/rust-glx"
+
+[target.x86_64-unknown-linux-gnu.dependencies.glx]
+git = "https://github.com/servo/rust-glx"
+
+[target.arm-unknown-linux-gnueabihf.dependencies.glx]
+git = "https://github.com/servo/rust-glx"
 
 [target.arm-linux-androideabi.dependencies.egl]
 git = "https://github.com/servo/rust-egl"

--- a/src/platform/android/surface.rs
+++ b/src/platform/android/surface.rs
@@ -13,8 +13,8 @@ use texturegl::Texture;
 
 use euclid::size::Size2D;
 use gleam::gl::{egl_image_target_texture2d_oes, TEXTURE_2D, TexImage2D, BGRA_EXT, UNSIGNED_BYTE};
-use egl::egl::EGLDisplay;
-use egl::eglext::{EGLImageKHR, DestroyImageKHR};
+use egl::types::{EGLDisplay, EGLImageKHR};
+use egl::DestroyImageKHR;
 use libc::c_void;
 use skia::{SkiaSkNativeSharedGLContextRef, SkiaSkNativeSharedGLContextStealSurface};
 use std::iter::repeat;
@@ -145,7 +145,9 @@ impl EGLImageNativeSurface {
         match self.image {
             None => {},
             Some(image_khr) => {
-                DestroyImageKHR(graphics_context.display, image_khr);
+                unsafe {
+                    DestroyImageKHR(graphics_context.display, image_khr);
+                }
                 mem::replace(&mut self.image, None);
             }
         }


### PR DESCRIPTION
This will remove the rust-glx dependency (which does just this), and the rust-egl dependency, which uses manual bindings.

I wonder if just updating rust-egl to generate the bindings is a better alternative, since azure, the gonk port, and glutin_app use it.

What do you think @glennw?