### PR TITLE
Remove stride argument from NativeSurface factory

### DIFF
--- a/src/platform/android/surface.rs
+++ b/src/platform/android/surface.rs
@@ -85,7 +85,7 @@ impl EGLImageNativeSurface {
     }
 
     /// This may only be called on the case of CPU rendering.
-    pub fn new(_: &NativePaintingGraphicsContext, size: Size2D<i32>, _stride: i32) -> EGLImageNativeSurface {
+    pub fn new(_: &NativePaintingGraphicsContext, size: Size2D<i32>) -> EGLImageNativeSurface {
         let len = size.width * size.height * 4;
         let bitmap: Vec<u8> = repeat(0).take(len as usize).collect();
 

--- a/src/platform/linux/surface.rs
+++ b/src/platform/linux/surface.rs
@@ -246,7 +246,7 @@ impl PixmapNativeSurface {
         }
     }
 
-    pub fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>, _stride: i32)
+    pub fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>)
            -> PixmapNativeSurface {
         unsafe {
             // Create the pixmap.

--- a/src/platform/macos/surface.rs
+++ b/src/platform/macos/surface.rs
@@ -176,10 +176,7 @@ impl IOSurfaceNativeSurface {
         }
     }
 
-    pub fn new(_: &NativePaintingGraphicsContext,
-               size: Size2D<i32>,
-               stride: i32)
-               -> IOSurfaceNativeSurface {
+    pub fn new(_: &NativePaintingGraphicsContext, size: Size2D<i32>) -> IOSurfaceNativeSurface {
         unsafe {
             let width_key: CFString = TCFType::wrap_under_get_rule(kIOSurfaceWidth);
             let width_value: CFNumber = CFNumber::from_i32(size.width);
@@ -188,7 +185,7 @@ impl IOSurfaceNativeSurface {
             let height_value: CFNumber = CFNumber::from_i32(size.height);
 
             let bytes_per_row_key: CFString = TCFType::wrap_under_get_rule(kIOSurfaceBytesPerRow);
-            let bytes_per_row_value: CFNumber = CFNumber::from_i32(stride);
+            let bytes_per_row_value: CFNumber = CFNumber::from_i32(size.width * 4);
 
             let bytes_per_elem_key: CFString =
                 TCFType::wrap_under_get_rule(kIOSurfaceBytesPerElement);

--- a/src/platform/surface.rs
+++ b/src/platform/surface.rs
@@ -51,14 +51,11 @@ pub enum NativeSurface {
 #[cfg(target_os="linux")]
 impl NativeSurface {
     /// Creates a new native surface with uninitialized data.
-    pub fn new(native_context: &NativePaintingGraphicsContext,
-               size: Size2D<i32>,
-               stride: i32)
-               -> NativeSurface {
+    pub fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>) -> NativeSurface {
         if native_context.display == ptr::null_mut() {
-            NativeSurface::MemoryBuffer(MemoryBufferNativeSurface::new(native_context, size, stride))
+            NativeSurface::MemoryBuffer(MemoryBufferNativeSurface::new(native_context, size))
         } else {
-            NativeSurface::Pixmap(PixmapNativeSurface::new(native_context, size, stride))
+            NativeSurface::Pixmap(PixmapNativeSurface::new(native_context, size))
         }
    }
 }
@@ -66,22 +63,16 @@ impl NativeSurface {
 #[cfg(target_os="macos")]
 impl NativeSurface {
     /// Creates a new native surface with uninitialized data.
-    pub fn new(native_context: &NativePaintingGraphicsContext,
-               size: Size2D<i32>,
-               stride: i32)
-               -> NativeSurface {
-        NativeSurface::IOSurface(IOSurfaceNativeSurface::new(native_context, size, stride))
+    pub fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>) -> NativeSurface {
+        NativeSurface::IOSurface(IOSurfaceNativeSurface::new(native_context, size))
    }
 }
 
 #[cfg(target_os="android")]
 impl NativeSurface {
     /// Creates a new native surface with uninitialized data.
-    pub fn new(native_context: &NativePaintingGraphicsContext,
-               size: Size2D<i32>,
-               stride: i32)
-               -> NativeSurface {
-        NativeSurface::EGLImage(EGLImageNativeSurface::new(native_context, size, stride))
+    pub fn new(native_context: &NativePaintingGraphicsContext, size: Size2D<i32>) -> NativeSurface {
+        NativeSurface::EGLImage(EGLImageNativeSurface::new(native_context, size))
    }
 }
 
@@ -198,7 +189,7 @@ pub struct MemoryBufferNativeSurface {
 }
 
 impl MemoryBufferNativeSurface {
-    pub fn new(_: &NativePaintingGraphicsContext, _: Size2D<i32>, _: i32) -> MemoryBufferNativeSurface {
+    pub fn new(_: &NativePaintingGraphicsContext, _: Size2D<i32>) -> MemoryBufferNativeSurface {
         MemoryBufferNativeSurface{
             bytes: vec!(),
         }


### PR DESCRIPTION
It is unused for Linux and Android and for Mac it is always hard-coded
to width * 4 bytes.