### PR TITLE
layers: Multiply `world_rect.origin` during the HiDPI scale factor in `get_buffer_requests_in_rect`.

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -143,12 +143,13 @@ impl<T> Layer<T> {
                                scale: ScaleFactor<LayerPixel, DevicePixel, f32>)
                                -> Vec<BufferRequest> {
         let mut tile_grid = self.tile_grid.borrow_mut();
-        return tile_grid.get_buffer_requests_in_rect(rect_in_layer * scale,
-                                                     viewport_in_layer * scale,
-                                                     self.bounds.borrow().size * scale,
-                                                     &self.transform_state.borrow().world_rect.origin,
-                                                     &self.transform_state.borrow().final_transform,
-                                                     *self.content_age.borrow());
+        tile_grid.get_buffer_requests_in_rect(rect_in_layer * scale,
+                                              viewport_in_layer * scale,
+                                              self.bounds.borrow().size * scale,
+                                              &(self.transform_state.borrow().world_rect.origin *
+                                                scale.get()),
+                                              &self.transform_state.borrow().final_transform,
+                                              *self.content_age.borrow())
     }
 
     pub fn resize(&self, new_size: TypedSize2D<LayerPixel, f32>) {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -58,16 +58,17 @@ impl<T> Scene<T> {
             // should simply reuse a cached version of the intersection.
             match layer.transform_state.borrow().screen_rect {
                 Some(ref screen_rect) => {
-                    child_dirty_rect = match dirty_rect.to_untyped().intersection(&screen_rect.rect) {
-                        Some(child_dirty_rect) => {
-                            Rect::from_untyped(&child_dirty_rect)
+                    child_dirty_rect =
+                        match dirty_rect.to_untyped().intersection(&screen_rect.rect) {
+                            Some(child_dirty_rect) => {
+                                Rect::from_untyped(&child_dirty_rect)
+                            }
+                            None => {
+                                // The layer is entirely clipped by the dirty
+                                // rect, so early exit.
+                                return;
+                            }
                         }
-                        None => {
-                            // The layer is entirely clipped by the dirty
-                            // rect, so early exit.
-                            return;
-                        }
-                    }
                 }
                 None => {
                     // The layer is entirely clipped, and it masks children,


### PR DESCRIPTION
Fixes tiles disappearing when scrolling down sometimes.

r? @glennw