### PR TITLE
Collapse all display related structs

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -16,8 +16,7 @@ use euclid::scale_factor::ScaleFactor;
 use euclid::size::{Size2D, TypedSize2D};
 use euclid::point::{Point2D, TypedPoint2D};
 use euclid::rect::{Rect, TypedRect};
-use platform::surface::{NativeCompositingGraphicsContext, NativePaintingGraphicsContext};
-use platform::surface::NativeSurface;
+use platform::surface::{NativeDisplay, NativeSurface};
 use std::cell::{RefCell, RefMut};
 use std::rc::Rc;
 use util::{project_rect_to_screen, ScreenRect};
@@ -172,8 +171,8 @@ impl<T> Layer<T> {
         self.content_age.borrow_mut().next();
     }
 
-    pub fn create_textures(&self, graphics_context: &NativeCompositingGraphicsContext) {
-        self.tile_grid.borrow_mut().create_textures(graphics_context);
+    pub fn create_textures(&self, display: &NativeDisplay) {
+        self.tile_grid.borrow_mut().create_textures(display);
     }
 
     pub fn do_for_all_tiles<F: FnMut(&Tile)>(&self, f: F) {
@@ -291,9 +290,9 @@ impl LayerBuffer {
     }
 
     /// Destroys the layer buffer. Painting task only.
-    pub fn destroy(self, graphics_context: &NativePaintingGraphicsContext) {
+    pub fn destroy(self, display: &NativeDisplay) {
         let mut this = self;
-        this.native_surface.destroy(graphics_context)
+        this.native_surface.destroy(display)
     }
 }
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -14,7 +14,7 @@ use texturegl::Texture;
 use texturegl::Flip::VerticalFlip;
 use texturegl::TextureTarget::{TextureTarget2D, TextureTargetRectangle};
 use tiling::Tile;
-use platform::surface::NativeCompositingGraphicsContext;
+use platform::surface::NativeDisplay;
 
 use euclid::matrix::Matrix4;
 use euclid::rect::Rect;
@@ -407,7 +407,7 @@ pub struct RenderContext {
     buffers: Buffers,
 
     /// The platform-specific graphics context.
-    compositing_context: NativeCompositingGraphicsContext,
+    compositing_display: NativeDisplay,
 
     /// Whether to show lines at border and tile boundaries for debugging purposes.
     show_debug_borders: bool,
@@ -416,7 +416,7 @@ pub struct RenderContext {
 }
 
 impl RenderContext {
-    pub fn new(compositing_context: NativeCompositingGraphicsContext,
+    pub fn new(compositing_display: NativeDisplay,
                show_debug_borders: bool,
                force_near_texture_filter: bool) -> RenderContext {
         gl::enable(gl::TEXTURE_2D);
@@ -434,7 +434,7 @@ impl RenderContext {
             texture_rectangle_program: texture_rectangle_program,
             solid_color_program: solid_color_program,
             buffers: RenderContext::init_buffers(),
-            compositing_context: compositing_context,
+            compositing_display: compositing_display,
             show_debug_borders: show_debug_borders,
             force_near_texture_filter: force_near_texture_filter,
         }
@@ -554,7 +554,7 @@ impl RenderContext {
                        transform: &Matrix4,
                        projection: &Matrix4,
                        clip_rect: Option<Rect<f32>>,
-                       gfx_context: &NativeCompositingGraphicsContext) {
+                       gfx_context: &NativeDisplay) {
         let ts = layer.transform_state.borrow();
 
         let transform = transform.mul(&ts.final_transform);
@@ -688,7 +688,7 @@ impl RenderContext {
                             transform: &Matrix4,
                             projection: &Matrix4,
                             mut clip_rect: Option<Rect<f32>>,
-                            gfx_context: &NativeCompositingGraphicsContext) {
+                            gfx_context: &NativeDisplay) {
 
         clip_rect = match (clip_rect, context.clip_rect) {
             (Some(current_clip), Some(context_clip)) => {
@@ -783,5 +783,5 @@ pub fn render_scene<T>(root_layer: Rc<Layer<T>>,
                                      &transform,
                                      &projection,
                                      None,
-                                     &render_context.compositing_context);
+                                     &render_context.compositing_display);
 }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -9,7 +9,7 @@
 
 use geometry::{DevicePixel, LayerPixel};
 use layers::{BufferRequest, ContentAge, LayerBuffer};
-use platform::surface::NativeCompositingGraphicsContext;
+use platform::surface::NativeDisplay;
 use texturegl::Texture;
 use util::project_rect_to_screen;
 
@@ -67,7 +67,7 @@ impl Tile {
         return old_buffer;
     }
 
-    fn create_texture(&mut self, graphics_context: &NativeCompositingGraphicsContext) {
+    fn create_texture(&mut self, display: &NativeDisplay) {
         match self.buffer {
             Some(ref buffer) => {
                 let size = Size2D::new(buffer.screen_pos.size.width as isize,
@@ -82,7 +82,7 @@ impl Tile {
                 self.texture = Texture::new_with_buffer(buffer);
                 debug!("Tile: binding to native surface {}",
                        buffer.native_surface.get_id() as isize);
-                buffer.native_surface.bind_to_texture(graphics_context, &self.texture, size);
+                buffer.native_surface.bind_to_texture(display, &self.texture, size);
 
                 // Set the layer's rect.
                 self.bounds = Some(Rect::from_untyped(&buffer.rect));
@@ -329,9 +329,9 @@ impl TileGrid {
         return collected_buffers;
     }
 
-    pub fn create_textures(&mut self, graphics_context: &NativeCompositingGraphicsContext) {
+    pub fn create_textures(&mut self, display: &NativeDisplay) {
         for (_, ref mut tile) in self.tiles.iter_mut() {
-            tile.create_texture(graphics_context);
+            tile.create_texture(display);
         }
     }
 }


### PR DESCRIPTION
This simplifies creation and management of these bits of
metadata which should really be per-display. This will also make
it easier to centralize the surface cache.