### PR TITLE
Allow BufferRequests to carry cached LayerBuffers

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -222,16 +222,18 @@ impl<T> Layer<T> {
 }
 
 /// A request from the compositor to the renderer for tiles that need to be (re)displayed.
-#[derive(Clone, Copy)]
 pub struct BufferRequest {
-    // The rect in pixels that will be drawn to the screen
+    /// The rect in pixels that will be drawn to the screen
     pub screen_rect: Rect<usize>,
 
-    // The rect in page coordinates that this tile represents
+    /// The rect in page coordinates that this tile represents
     pub page_rect: Rect<f32>,
 
     /// The content age of that this BufferRequest corresponds to.
     pub content_age: ContentAge,
+
+    /// A cached LayerBuffer that can be used to avoid allocating a new one.
+    pub layer_buffer: Option<Box<LayerBuffer>>,
 }
 
 impl BufferRequest {
@@ -241,6 +243,7 @@ impl BufferRequest {
             screen_rect: screen_rect,
             page_rect: page_rect,
             content_age: content_age,
+            layer_buffer: None,
         }
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -38,8 +38,7 @@ impl<T> Scene<T> {
                                          viewport_rect: TypedRect<LayerPixel, f32>,
                                          layers_and_requests: &mut Vec<(Rc<Layer<T>>,
                                                                         Vec<BufferRequest>)>,
-                                         unused_buffers: &mut Vec<(Rc<Layer<T>>,
-                                                                        Vec<Box<LayerBuffer>>)>) {
+                                         unused_buffers: &mut Vec<Box<LayerBuffer>>) {
         // Get buffers for this layer, in global (screen) coordinates.
         let requests = layer.get_buffer_requests(dirty_rect,
                                                  viewport_rect,
@@ -47,7 +46,7 @@ impl<T> Scene<T> {
         if !requests.is_empty() {
             layers_and_requests.push((layer.clone(), requests));
         }
-        unused_buffers.push((layer.clone(), layer.collect_unused_buffers()));
+        unused_buffers.extend(layer.collect_unused_buffers().into_iter());
 
         // If this layer masks its children, we don't need to ask for tiles outside the
         // boundaries of this layer.
@@ -89,7 +88,7 @@ impl<T> Scene<T> {
 
     pub fn get_buffer_requests(&mut self,
                                requests: &mut Vec<(Rc<Layer<T>>, Vec<BufferRequest>)>,
-                               unused_buffers: &mut Vec<(Rc<Layer<T>>, Vec<Box<LayerBuffer>>)>) {
+                               unused_buffers: &mut Vec<Box<LayerBuffer>>) {
         let root_layer = match self.root {
             Some(ref root_layer) => root_layer.clone(),
             None => return,


### PR DESCRIPTION
If Servo's compositor can cache unused LayerBuffers, then BufferRequests
should include a potentially cached layer. This also means that we
no longer have to associate unused buffers with their originating layer,
since the compositor caches then all together.