### PR TITLE
Have NativeSurface store their size

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -272,8 +272,7 @@ pub struct LayerBuffer {
 impl LayerBuffer {
     /// Returns the amount of memory used by the tile
     pub fn get_mem(&self) -> usize {
-        // This works for now, but in the future we may want a better heuristic
-        self.screen_pos.size.width * self.screen_pos.size.height
+        self.native_surface.get_memory_usage()
     }
 
     /// Returns true if the tile is displayable at the given scale

--- a/src/platform/macos/surface.rs
+++ b/src/platform/macos/surface.rs
@@ -48,6 +48,7 @@ impl NativeDisplay {
 pub struct IOSurfaceNativeSurface {
     io_surface_id: Option<io_surface::IOSurfaceID>,
     will_leak: bool,
+    pub size: Size2D<i32>,
 }
 
 impl IOSurfaceNativeSurface {
@@ -88,17 +89,15 @@ impl IOSurfaceNativeSurface {
             IOSurfaceNativeSurface {
                 io_surface_id: Some(id),
                 will_leak: true,
+                size: size,
             }
         }
     }
 
-    pub fn bind_to_texture(&self,
-                           _: &NativeDisplay,
-                           texture: &Texture,
-                           size: Size2D<isize>) {
+    pub fn bind_to_texture(&self, _: &NativeDisplay, texture: &Texture) {
         let _bound_texture = texture.bind();
         let io_surface = io_surface::lookup(self.io_surface_id.unwrap());
-        io_surface.bind_to_gl_texture(Size2D::new(size.width as i32, size.height as i32))
+        io_surface.bind_to_gl_texture(self.size);
     }
 
     pub fn upload(&mut self, _: &NativeDisplay, data: &[u8]) {
@@ -130,11 +129,10 @@ impl IOSurfaceNativeSurface {
     }
 
     pub fn gl_rasterization_context(&mut self,
-                                    display: &NativeDisplay,
-                                    size: Size2D<i32>)
+                                    display: &NativeDisplay)
                                     -> Option<GLRasterizationContext> {
         GLRasterizationContext::new(display.pixel_format,
                                     io_surface::lookup(self.io_surface_id.unwrap()).obj,
-                                    size)
+                                    self.size)
     }
 }

--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -70,9 +70,6 @@ impl Tile {
     fn create_texture(&mut self, display: &NativeDisplay) {
         match self.buffer {
             Some(ref buffer) => {
-                let size = Size2D::new(buffer.screen_pos.size.width as isize,
-                                       buffer.screen_pos.size.height as isize);
-
                 // If we already have a texture it should still be valid.
                 if !self.texture.is_zero() {
                     return;
@@ -82,7 +79,7 @@ impl Tile {
                 self.texture = Texture::new_with_buffer(buffer);
                 debug!("Tile: binding to native surface {}",
                        buffer.native_surface.get_id() as isize);
-                buffer.native_surface.bind_to_texture(display, &self.texture, size);
+                buffer.native_surface.bind_to_texture(display, &self.texture);
 
                 // Set the layer's rect.
                 self.bounds = Some(Rect::from_untyped(&buffer.rect));


### PR DESCRIPTION
This will allow the Servo surface cache to store NativeSurfaces instead
of LayerBuffers and also allow the surface cache to move into
rust-layers, if that is useful. It also simplifies how some methods are
called.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/194)
<!-- Reviewable:end -->
