### PR TITLE
Send NativeSurfaces with BufferRequests

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -241,8 +241,8 @@ pub struct BufferRequest {
     /// The content age of that this BufferRequest corresponds to.
     pub content_age: ContentAge,
 
-    /// A cached LayerBuffer that can be used to avoid allocating a new one.
-    pub layer_buffer: Option<Box<LayerBuffer>>,
+    /// A cached NativeSurface that can be used to avoid allocating a new one.
+    pub native_surface: Option<NativeSurface>,
 }
 
 impl BufferRequest {
@@ -252,7 +252,7 @@ impl BufferRequest {
             screen_rect: screen_rect,
             page_rect: page_rect,
             content_age: content_age,
-            layer_buffer: None,
+            native_surface: None,
         }
     }
 }


### PR DESCRIPTION
This will allow Servo to only create LayerBuffers in a single place, but
still cache NativeSurfaces.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/195)
<!-- Reviewable:end -->
