### PR TITLE
Update to latest skia

### DIFF
--- a/src/platform/linux/surface.rs
+++ b/src/platform/linux/surface.rs
@@ -16,12 +16,14 @@ use texturegl::Texture;
 use euclid::size::Size2D;
 use libc::{c_int, c_uint, c_void};
 use glx;
+use skia::gl_context::{GLContext, PlatformDisplayData};
 use skia::gl_rasterization_context::GLRasterizationContext;
 use std::ascii::OwnedAsciiExt;
 use std::ffi::CStr;
 use std::mem;
 use std::ptr;
 use std::str;
+use std::sync::Arc;
 use x11::xlib;
 
 /// The display, visual info, and framebuffer configuration. This is needed in order to bind to a
@@ -135,6 +137,13 @@ impl NativeDisplay {
                     .to_string()
                     .into_ascii_lowercase();
             glx_vendor.contains("nvidia") || glx_vendor.contains("ati")
+        }
+    }
+
+    pub fn platform_display_data(&self) -> PlatformDisplayData {
+        PlatformDisplayData {
+            display: self.display,
+            visual_info: self.visual_info,
         }
     }
 }
@@ -265,8 +274,8 @@ impl PixmapNativeSurface {
     }
 
     pub fn gl_rasterization_context(&mut self,
-                                    display: &NativeDisplay)
+                                    gl_context: Arc<GLContext>)
                                     -> Option<GLRasterizationContext> {
-        GLRasterizationContext::new(display.display, display.visual_info, self.pixmap, self.size)
+        GLRasterizationContext::new(gl_context, self.pixmap, self.size)
     }
 }

--- a/src/platform/macos/surface.rs
+++ b/src/platform/macos/surface.rs
@@ -20,10 +20,12 @@ use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use euclid::size::Size2D;
 use io_surface;
+use skia::gl_context::{GLContext, PlatformDisplayData};
 use skia::gl_rasterization_context::GLRasterizationContext;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::Arc;
 
 thread_local!(static IO_SURFACE_REPOSITORY: Rc<RefCell<HashMap<io_surface::IOSurfaceID, io_surface::IOSurface>>> =
     Rc::new(RefCell::new(HashMap::new())));
@@ -40,6 +42,12 @@ impl NativeDisplay {
             NativeDisplay {
                 pixel_format: cgl::CGLGetPixelFormat(cgl::CGLGetCurrentContext()),
             }
+        }
+    }
+
+    pub fn platform_display_data(&self) -> PlatformDisplayData {
+        PlatformDisplayData {
+            pixel_format: self.pixel_format,
         }
     }
 }
@@ -129,9 +137,9 @@ impl IOSurfaceNativeSurface {
     }
 
     pub fn gl_rasterization_context(&mut self,
-                                    display: &NativeDisplay)
+                                    gl_context: Arc<GLContext>)
                                     -> Option<GLRasterizationContext> {
-        GLRasterizationContext::new(display.pixel_format,
+        GLRasterizationContext::new(gl_context,
                                     io_surface::lookup(self.io_surface_id.unwrap()).obj,
                                     self.size)
     }

--- a/src/platform/surface.rs
+++ b/src/platform/surface.rs
@@ -14,6 +14,7 @@ use texturegl::Texture;
 
 use euclid::size::Size2D;
 use skia::gl_rasterization_context::GLRasterizationContext;
+use skia::gl_context::GLContext;
 use std::sync::Arc;
 
 #[cfg(not(target_os="android"))]
@@ -173,12 +174,13 @@ impl NativeSurface {
     }
 
     pub fn gl_rasterization_context(&mut self,
-                                    display: &NativeDisplay)
+                                    gl_context: Arc<GLContext>)
                                     -> Option<Arc<GLRasterizationContext>> {
-        match native_surface_method_mut!(self gl_rasterization_context (display)) {
+        match native_surface_method_mut!(self gl_rasterization_context (gl_context)) {
             Some(context) => Some(Arc::new(context)),
             None => None,
         }
+
     }
 
     /// Get the memory usage of this native surface. This memory may be allocated
@@ -249,7 +251,7 @@ impl MemoryBufferNativeSurface {
     }
 
     pub fn gl_rasterization_context(&mut self,
-                                    _: &NativeDisplay)
+                                    _: Arc<GLContext>)
                                     -> Option<GLRasterizationContext> {
         None
     }


### PR DESCRIPTION
The rust version of Skia now uses a GLContext struct to preserve
contexts between rasterization targets.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/198)
<!-- Reviewable:end -->
