### PR TITLE
Simplify some code and remove an inaccurate comment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gcc-4.7 g++-4.7; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 20; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 20; fi
+# We pin rust here, because aster (0.4.0) is broken with the latest
+# rust nightly. Once aster is fixed we can change this back to 'nightly.'
 rust:
-  - nightly
+  - nightly-2015-07-30
 branches:
   except:
     - master


### PR DESCRIPTION
This particular comment is likely left over from a previous iteration of
the get_buffer_requests_for_layer function. We also remove one mutable
variable in favor of an immutable one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/200)
<!-- Reviewable:end -->
