### PR TITLE
Reuse MemoryBufferNativeSurface for Android

### DIFF
--- a/src/platform/linux/surface.rs
+++ b/src/platform/linux/surface.rs
@@ -257,6 +257,10 @@ impl PixmapNativeSurface {
         self.pixmap as isize
     }
 
+    pub fn get_size(&self) -> Size2D<i32> {
+        self.size
+    }
+
     pub fn destroy(&mut self, display: &NativeDisplay) {
         unsafe {
             assert!(self.pixmap != 0);

--- a/src/platform/macos/surface.rs
+++ b/src/platform/macos/surface.rs
@@ -120,6 +120,10 @@ impl IOSurfaceNativeSurface {
         }
     }
 
+    pub fn get_size(&self) -> Size2D<i32> {
+        self.size
+    }
+
     pub fn destroy(&mut self, _: &NativeDisplay) {
         IO_SURFACE_REPOSITORY.with(|ref r| {
             r.borrow_mut().remove(&self.io_surface_id.unwrap())


### PR DESCRIPTION
Android native surfaces are either memory buffers or EGLImages.
Currently the Android memory buffer surface implementation exists in
addition to the MemoryBufferNativeSurface which is unused for Android.
This change makes the Android native surface an enum that can either
hold a MemoryBufferNativeSurface or an EGLImage-based native surface.
The end result is that there is now only one implementation of memory
buffer surfaces shared among all platforms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/202)
<!-- Reviewable:end -->
