### PR TITLE
Get rust-layer compiling on travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gcc-4.7 g++-4.7; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 20; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 20; fi
-# We pin rust here, because aster (0.4.0) is broken with the latest
-# rust nightly. Once aster is fixed we can change this back to 'nightly.'
 rust:
-  - nightly-2015-07-30
+  - nightly
 branches:
   except:
     - master

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![allow(raw_pointer_derive)]
 #![feature(vec_push_all, iter_arith)]
-#![cfg_attr(target_os="linux", feature(owned_ascii_ext))]
 #![cfg_attr(target_os="macos", feature(collections))]
 
 extern crate azure;

--- a/src/platform/linux/surface.rs
+++ b/src/platform/linux/surface.rs
@@ -18,7 +18,7 @@ use libc::{c_int, c_uint, c_void};
 use glx;
 use skia::gl_context::{GLContext, PlatformDisplayData};
 use skia::gl_rasterization_context::GLRasterizationContext;
-use std::ascii::OwnedAsciiExt;
+use std::ascii::AsciiExt;
 use std::ffi::CStr;
 use std::mem;
 use std::ptr;
@@ -135,7 +135,7 @@ impl NativeDisplay {
                     .ok()
                     .expect("GLX client vendor string not in UTF-8 format.")
                     .to_string()
-                    .into_ascii_lowercase();
+                    .to_ascii_lowercase();
             glx_vendor.contains("nvidia") || glx_vendor.contains("ati")
         }
     }


### PR DESCRIPTION
To get rust-layers compiling on travis, it needs to be compatible with the nightly version of rust, since that is what the latest versions of aster depend on.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/203)
<!-- Reviewable:end -->
