### PR TITLE
Lock x11 to 2.0 instead of 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,19 +37,19 @@ git = "https://github.com/servo/rust-glx"
 git = "https://github.com/servo/rust-glx"
 
 [target.i686-unknown-linux-gnu.dependencies.x11]
-version = "2.0.0"
+version = "2.0"
 features = ["xlib"]
 
 [target.x86_64-unknown-linux-gnu.dependencies.x11]
-version = "2.0.0"
+version = "2.0"
 features = ["xlib"]
 
 [target.arm-unknown-linux-gnueabihf.dependencies.x11]
-version = "2.0.0"
+version = "2.0"
 features = ["xlib"]
 
 [target.aarch64-unknown-linux-gnu.dependencies.x11]
-version = "2.0.0"
+version = "2.0"
 features = ["xlib"]
 
 [target.arm-linux-androideabi.dependencies.egl]


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/206)
<!-- Reviewable:end -->
