### PR TITLE
M1506 : Refactor GLES2

### DIFF
--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -477,12 +477,15 @@ pub struct RenderContext {
     show_debug_borders: bool,
 
     force_near_texture_filter: bool,
+    //graphics_select:String,
 }
 
 impl RenderContext {
     pub fn new(compositing_display: NativeDisplay,
                show_debug_borders: bool,
-               force_near_texture_filter: bool) -> RenderContext {
+               force_near_texture_filter: bool,
+               graphics_select: String) -> RenderContext {
+               println!("Graphics select: {}",graphics_select);
         gl::enable(gl::TEXTURE_2D);
 
         // Each layer uses premultiplied alpha!
@@ -501,6 +504,7 @@ impl RenderContext {
             compositing_display: compositing_display,
             show_debug_borders: show_debug_borders,
             force_near_texture_filter: force_near_texture_filter,
+            //graphics_select: graphics_select,
         }
     }
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -496,6 +496,15 @@ impl RenderContext {
         // Each layer uses premultiplied alpha!
         gl::enable(gl::BLEND);
         gl::blend_func(gl::ONE, gl::ONE_MINUS_SRC_ALPHA);
+	let mut graphics_select = GraphicOption::GL;
+	if(graphics_option == true)
+	{
+		graphics_select = GraphicOption::GL;
+	}
+	else
+	{
+		graphics_select = GraphicOption::ES2;
+	}
 
         let texture_2d_program = TextureProgram::create_2d_program();
         let solid_color_program = SolidColorProgram::new();

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -481,7 +481,7 @@ pub struct RenderContext {
     show_debug_borders: bool,
 
     force_near_texture_filter: bool,
-    graphics_select: GraphicOption,
+
 }
 
 impl RenderContext {
@@ -492,16 +492,6 @@ impl RenderContext {
                
         gl::enable(gl::TEXTURE_2D);
 
-	if(graphics_option)
-	{
-		println!("GL is selected");
-		graphics_select = GraphicOption::GL;
-	}
-	else
-	{	
-		println!("ES2 is selected");
-		graphics_select = GraphicOption::ES2;
-	}
 	
         // Each layer uses premultiplied alpha!
         gl::enable(gl::BLEND);
@@ -519,6 +509,8 @@ impl RenderContext {
             compositing_display: compositing_display,
             show_debug_borders: show_debug_borders,
             force_near_texture_filter: force_near_texture_filter,
+
+
         }
     }
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -477,7 +477,6 @@ pub struct RenderContext {
     show_debug_borders: bool,
 
     force_near_texture_filter: bool,
-    //graphics_select:String,
 }
 
 impl RenderContext {
@@ -485,7 +484,7 @@ impl RenderContext {
                show_debug_borders: bool,
                force_near_texture_filter: bool,
                graphics_select: String) -> RenderContext {
-               println!("Graphics select: {}",graphics_select);
+               println!("Graphics select: {}",graphics_select); //Debug for GL/ES2 develpment
         gl::enable(gl::TEXTURE_2D);
 
         // Each layer uses premultiplied alpha!
@@ -504,7 +503,6 @@ impl RenderContext {
             compositing_display: compositing_display,
             show_debug_borders: show_debug_borders,
             force_near_texture_filter: force_near_texture_filter,
-            //graphics_select: graphics_select,
         }
     }
 

--- a/src/rendergl.rs
+++ b/src/rendergl.rs
@@ -463,6 +463,10 @@ impl<T> RenderContext3DBuilder<T> for Rc<Layer<T>> {
     }
 }
 
+enum GraphicOption {
+    GL,
+    ES2,
+  }
 #[derive(Copy, Clone)]
 pub struct RenderContext {
     texture_2d_program: TextureProgram,
@@ -477,16 +481,28 @@ pub struct RenderContext {
     show_debug_borders: bool,
 
     force_near_texture_filter: bool,
+    graphics_select: GraphicOption,
 }
 
 impl RenderContext {
     pub fn new(compositing_display: NativeDisplay,
                show_debug_borders: bool,
                force_near_texture_filter: bool,
-               graphics_select: String) -> RenderContext {
-               println!("Graphics select: {}",graphics_select); //Debug for GL/ES2 develpment
+               graphics_option: bool) -> RenderContext {
+               
         gl::enable(gl::TEXTURE_2D);
 
+	if(graphics_option)
+	{
+		println!("GL is selected");
+		graphics_select = GraphicOption::GL;
+	}
+	else
+	{	
+		println!("ES2 is selected");
+		graphics_select = GraphicOption::ES2;
+	}
+	
         // Each layer uses premultiplied alpha!
         gl::enable(gl::BLEND);
         gl::blend_func(gl::ONE, gl::ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
Added a flag to RenderContext::new in rendergl.rs, this is in reference to adding a new command-line option to allow selecting the graphics backend (GL or ES2)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-layers/212)
<!-- Reviewable:end -->
